### PR TITLE
Pin the action version comments to the exact released tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,20 +19,20 @@ jobs:
         steps:
             - id: checkout
               name: Checkout
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 
             - id: setup_node
               name: Set up Node.js
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 22
                   cache: npm
 
             - id: setup_php
               name: Set up PHP version ${{ matrix.php }}
-              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: ${{ matrix.php }}
                   tools: composer:v2
@@ -48,7 +48,7 @@ jobs:
 
             - id: composer-cache-dependencies
               name: Cache Composer dependencies
-              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: ${{ steps.composer-cache-vars.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ steps.composer-cache-vars.outputs.timestamp }}
@@ -167,13 +167,13 @@ jobs:
         steps:
             - id: checkout
               name: Checkout
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 
             - id: setup_php
               name: Set up PHP version 8.4
-              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '8.4'
                   extensions: pdo_mysql


### PR DESCRIPTION
zizmor `ref-version-mismatch` flagged the floating major-tag comments (e.g. `# v6`, `# v2`, `# v5`) on the hash-pinned actions. The SHAs are correct; only the comments pointed at moving major tags.

Repoint each comment at the exact release its SHA resolves to, so the comment stays in sync with the pin and Dependabot mirrors the exact version on future bumps. No behaviour change — comment-only.