### PR TITLE
GH-131: Migrate expectExceptionMessage() to a regex matcher for PHPUnit 13

### DIFF
--- a/tests/Integration/TreeScopeTest.php
+++ b/tests/Integration/TreeScopeTest.php
@@ -86,7 +86,7 @@ final class TreeScopeTest extends IntegrationTestCase
         $tree = $this->importFixtureTree('records.ged');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown per-tree table "source"');
+        $this->expectExceptionMessageMatches('/' . preg_quote('Unknown per-tree table "source"', '/') . '/');
 
         TreeScope::table($tree, 'source');
     }


### PR DESCRIPTION
Fixes #131.

`expectExceptionMessage()` is deprecated in PHPUnit 13. With `composer.lock` untracked, PHP 8.5 resolves PHPUnit 13 and PHPStan's deprecation rule fails the `build (8.5)` job — blocking every PR merge.

Migrate the single call site to `expectExceptionMessageMatches()`, which is un-deprecated across the whole supported PHPUnit range. `preg_quote` keeps it an exact-substring match (no behaviour change).