### PR TITLE
GH-137: Pin date representatives to one coherent cross-calendar row

### DIFF
--- a/src/Support/Database/BirthDeathPairsQuery.php
+++ b/src/Support/Database/BirthDeathPairsQuery.php
@@ -87,14 +87,19 @@ final readonly class BirthDeathPairsQuery
                 // Pin the birth alias to the individual's lower-bound BIRT row,
                 // so a consumer's `MIN(birth.d_year)` / `MIN(birth.d_type)` are
                 // read from ONE coherent row — not column-wise from different
-                // rows — when an individual carries BIRT facts with DISTINCT
-                // julian days in more than one calendar. The residual exact
-                // julian-day cross-calendar tie (e.g. a Gregorian and a Julian
-                // transcription of the same physical day, whose native `d_year`
-                // differ by one) admits both rows and is NOT resolved here; it is
-                // the same documented per-column-MIN limitation as
-                // {@see DedupedEventDates} and is tracked separately.
-                $join->on('birth.d_julianday1', '=', 'birth_rep.min_jd');
+                // rows — when an individual carries BIRT facts in more than one
+                // calendar. The julian-day pin alone resolves DISTINCT-julian-day
+                // calendars; the `d_type` pin additionally resolves the exact
+                // julian-day cross-calendar tie (e.g. a Gregorian `1 JAN 1800`
+                // and a Julian `21 DEC 1799` transcription of the same physical
+                // day, whose native `d_year` differ by one) by selecting the
+                // lexicographically smallest calendar — the Gregorian row for a
+                // Gregorian/Julian tie (`@#DGREGORIAN@` < `@#DJULIAN@`) — so
+                // `birth.d_type` and `birth.d_year` cannot be drawn from
+                // different rows. Mirrors {@see DedupedEventDates}.
+                $join
+                    ->on('birth.d_julianday1', '=', 'birth_rep.min_jd')
+                    ->on('birth.d_type', '=', 'birth_rep.rep_type');
             })
             ->join('dates AS death', static function (JoinClause $join) use ($requireFullDate): void {
                 DateJoin::on(
@@ -110,29 +115,64 @@ final readonly class BirthDeathPairsQuery
     }
 
     /**
-     * Per-individual lower-bound BIRT row key: `d_file`, `d_gid` and the minimum
-     * resolvable `d_julianday1`. Mirrors the birth alias's own filters (a
-     * resolvable julian day, plus the full-date gate when the caller demands
-     * day-precision) so the representative is drawn from exactly the rows the
-     * birth join keeps.
+     * Per-individual lower-bound BIRT row key: `d_file`, `d_gid`, the minimum
+     * resolvable `d_julianday1` and the tie-break calendar `rep_type` — the
+     * lexicographically smallest `d_type` among the rows at that lower-bound
+     * julian day, so an exact same-julian-day cross-calendar tie pins to one
+     * coherent row instead of mixing columns. Mirrors the birth alias's own
+     * filters (a resolvable julian day, plus the full-date gate when the caller
+     * demands day-precision) so the representative is drawn from exactly the rows
+     * the birth join keeps.
      *
      * @param Tree $tree            The tree to scope the birth rows to
      * @param bool $requireFullDate Whether to restrict to day-precise rows (`d_day`/`d_mon` > 0)
      */
     private static function lowerBoundBirth(Tree $tree, bool $requireFullDate): Builder
     {
-        $query = TreeScope::table($tree, 'dates')
-            ->where('d_fact', '=', 'BIRT')
-            ->where('d_julianday1', '>', 0);
+        $lowerBound = self::birthRows($tree, $requireFullDate)
+            ->select(['d_file', 'd_gid', new Expression('MIN(d_julianday1) AS min_jd')])
+            ->groupBy('d_file', 'd_gid');
+
+        return self::birthRows($tree, $requireFullDate, 'b')
+            ->joinSub($lowerBound, 'lb', static function (JoinClause $join): void {
+                $join
+                    ->on('lb.d_file', '=', 'b.d_file')
+                    ->on('lb.d_gid', '=', 'b.d_gid')
+                    ->on('lb.min_jd', '=', 'b.d_julianday1');
+            })
+            ->groupBy('b.d_file', 'b.d_gid')
+            ->select([
+                'b.d_file',
+                'b.d_gid',
+                DateAggregate::min('b', 'd_julianday1', 'min_jd'),
+                DateAggregate::min('b', 'd_type', 'rep_type'),
+            ]);
+    }
+
+    /**
+     * The dated BIRT rows the representative is drawn from: a resolvable julian
+     * day, plus the day-precision gate when the caller demands it. Shared by the
+     * lower-bound subquery and its tie-break join-back so both read the same row
+     * universe.
+     *
+     * @param Tree    $tree            The tree to scope the birth rows to
+     * @param bool    $requireFullDate Whether to restrict to day-precise rows (`d_day`/`d_mon` > 0)
+     * @param ?string $alias           Optional table alias for the join-back copy
+     */
+    private static function birthRows(Tree $tree, bool $requireFullDate, ?string $alias = null): Builder
+    {
+        $prefix = $alias === null ? '' : $alias . '.';
+
+        $query = TreeScope::table($tree, 'dates', $alias)
+            ->where($prefix . 'd_fact', '=', 'BIRT')
+            ->where($prefix . 'd_julianday1', '>', 0);
 
         if ($requireFullDate) {
             $query
-                ->where('d_day', '>', 0)
-                ->where('d_mon', '>', 0);
+                ->where($prefix . 'd_day', '>', 0)
+                ->where($prefix . 'd_mon', '>', 0);
         }
 
-        return $query
-            ->select(['d_file', 'd_gid', new Expression('MIN(d_julianday1) AS min_jd')])
-            ->groupBy('d_file', 'd_gid');
+        return $query;
     }
 }

--- a/src/Support/Database/DedupedEventDates.php
+++ b/src/Support/Database/DedupedEventDates.php
@@ -44,16 +44,25 @@ use Illuminate\Database\Query\JoinClause;
  * that map to the same julian day) — without it that individual would surface
  * twice and split across two buckets, the very defect this helper exists to
  * remove. For a single-row individual the `GROUP BY` is a no-op. On a genuine
- * cross-calendar tie the surviving `d_year` / `d_mon` / `d_day` are the
- * per-column minima of the tied rows and may therefore be drawn from different
- * rows. The exact-once cardinality holds regardless — the `GROUP BY` emits one
- * row per individual, so every consumer counts each record once. A consumer
- * that reads a single column (century, year, month) is fully correct; a
- * consumer that combines `d_mon` and `d_day` from the same row (the zodiac
- * card) is also correct for the common range case, where the two bounds carry
- * distinct julian days and the join-back matches one whole row, and on the rare
- * tie could at worst place the still-counted-once individual in an adjacent
- * bucket.
+ * cross-calendar tie the representative is still ONE coherent row: among the
+ * rows sharing the lower-bound julian day the builder pins the
+ * lexicographically smallest `d_type`, so every exposed column — `d_type`,
+ * `d_year`, `d_mon`, `d_day` — is read from that single chosen calendar. The
+ * tie-break is deterministic rather than semantic, and that suffices: a tied
+ * Gregorian and Julian transcription of one day picks the Gregorian row
+ * (`@#DGREGORIAN@` < `@#DJULIAN@`). A Gregorian-scale winner (Gregorian or
+ * Julian) keeps its native year — the value webtrees core itself buckets by —
+ * while any other calendar (`@#DFRENCH R@`, `@#DHEBREW@`, …) converts the shared
+ * julian day through {@see \MagicSunday\Webtrees\Statistic\Support\Calc\GregorianDate};
+ * either way the single deterministic winner lands the record in the correct
+ * Gregorian period. This matters when a Gregorian and
+ * a Julian transcription of the same physical day carry diverging native years
+ * (`1 JAN 1800` Gregorian vs `21 DEC 1799` Julian): a naive column-wise `MIN()`
+ * would mix the Gregorian `d_type` with the Julian row's lower `d_year` and
+ * bucket the record one year — and at an edge one century — off. Pinning the
+ * whole row keeps `d_type`/`d_year` in lock-step, so a single-column consumer
+ * (century, year, month) and a multi-column one (the zodiac card's `d_mon` +
+ * `d_day`) alike see a self-consistent date.
  *
  * The returned builder reads like a virtual `event_dates` table with columns
  * `d_gid, d_type, d_year, d_mon, d_day, d_julianday1`; consumers chain their own
@@ -96,15 +105,39 @@ final readonly class DedupedEventDates
      */
     public static function query(Tree $tree, string $fact): Builder
     {
-        $representatives = self::restrictToDatedFact(TreeScope::table($tree, 'dates'), $fact, '')
+        $lowerBound = self::restrictToDatedFact(TreeScope::table($tree, 'dates'), $fact, '')
             ->select(['d_gid', new Expression('MIN(d_julianday1) AS min_jd')])
             ->groupBy('d_gid');
+
+        // Among the rows sharing that lower-bound julian day, pick a single
+        // calendar deterministically — the lexicographically smallest `d_type`.
+        // This resolves the exact same-julian-day cross-calendar tie, where two
+        // same-fact rows share `d_julianday1` but carry diverging native years
+        // (a Gregorian and a Julian transcription of one physical day), so the
+        // final join-back matches ONE whole row instead of mixing a Gregorian
+        // `d_type` with a Julian `d_year` column-wise. A Gregorian/Julian tie
+        // resolves to the Gregorian row (`@#DGREGORIAN@` < `@#DJULIAN@`); any
+        // other calendar bucketing through the shared julian day lands in the
+        // same Gregorian period whichever wins, so the choice is always correct.
+        $representatives = self::restrictToDatedFact(TreeScope::table($tree, 'dates', 'd'), $fact, 'd.')
+            ->joinSub($lowerBound, 'lb', static function (JoinClause $join): void {
+                $join
+                    ->on('lb.d_gid', '=', 'd.d_gid')
+                    ->on('lb.min_jd', '=', 'd.d_julianday1');
+            })
+            ->groupBy('d.d_gid')
+            ->select([
+                'd.d_gid',
+                DateAggregate::min('d', 'd_julianday1', 'min_jd'),
+                DateAggregate::min('d', 'd_type', 'rep_type'),
+            ]);
 
         $representativeRows = self::restrictToDatedFact(TreeScope::table($tree, 'dates', 'd'), $fact, 'd.')
             ->joinSub($representatives, 'rep', static function (JoinClause $join): void {
                 $join
                     ->on('rep.d_gid', '=', 'd.d_gid')
-                    ->on('rep.min_jd', '=', 'd.d_julianday1');
+                    ->on('rep.min_jd', '=', 'd.d_julianday1')
+                    ->on('rep.rep_type', '=', 'd.d_type');
             })
             ->groupBy('d.d_gid')
             ->select([

--- a/tests/Integration/BirthDeathPairsQueryTest.php
+++ b/tests/Integration/BirthDeathPairsQueryTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Test\Integration;
+
+use Fisharebest\Webtrees\DB;
+use MagicSunday\Webtrees\Statistic\Support\Calc\GregorianDate;
+use MagicSunday\Webtrees\Statistic\Support\Database\BirthDeathPairsQuery;
+use MagicSunday\Webtrees\Statistic\Support\Database\DateAggregate;
+use MagicSunday\Webtrees\Statistic\Support\Gedcom\RowCast;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+
+/**
+ * Integration test for {@see BirthDeathPairsQuery}, focused on the birth alias
+ * row-coherence guarantee its cohort consumers (child-mortality, lifespan-by-
+ * century) rely on. The pin to the lower-bound BIRT row keeps a consumer's
+ * `MIN(birth.d_year)` / `MIN(birth.d_type)` drawn from ONE row even when an
+ * individual carries BIRT facts in more than one calendar.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+#[CoversClass(BirthDeathPairsQuery::class)]
+#[UsesClass(DateAggregate::class)]
+#[UsesClass(GregorianDate::class)]
+#[UsesClass(RowCast::class)]
+final class BirthDeathPairsQueryTest extends IntegrationTestCase
+{
+    /**
+     * Two BIRT rows that describe the same physical day in different calendars —
+     * a Gregorian `1 JAN 1800` and a Julian `21 DEC 1799` — share the exact
+     * lower-bound julian day (2378497) but carry diverging Gregorian-scale native
+     * years (1800 vs 1799). Independent column minima would draw `birth_type`
+     * from the Gregorian row (`@#DGREGORIAN@` < `@#DJULIAN@`) but `birth_year`
+     * from the Julian row (1799 < 1800), so the converted cohort year would land
+     * one off — across the 1799/1800 century edge. The pin must surface ONE
+     * coherent row: the Gregorian birth, year 1800.
+     */
+    #[Test]
+    public function pinsBirthToOneCoherentRowOnAnExactCrossCalendarTie(): void
+    {
+        $tree = $this->importFixtureTree('birth-death-pairs-cross-calendar-tie.ged');
+
+        // The fixture individual carries only a DEAT (1 JAN 1803). Inject the two
+        // tied BIRT rows directly so their julian day is byte-identical — the
+        // tie cannot be expressed reliably through GEDCOM, where the calendar
+        // offset would have to be hand-computed.
+        DB::table('dates')->insert([
+            'd_gid'        => 'I1',
+            'd_file'       => $tree->id(),
+            'd_fact'       => 'BIRT',
+            'd_type'       => '@#DGREGORIAN@',
+            'd_day'        => 1,
+            'd_mon'        => 1,
+            'd_month'      => 'JAN',
+            'd_year'       => 1800,
+            'd_julianday1' => 2378497,
+            'd_julianday2' => 2378497,
+        ]);
+        DB::table('dates')->insert([
+            'd_gid'        => 'I1',
+            'd_file'       => $tree->id(),
+            'd_fact'       => 'BIRT',
+            'd_type'       => '@#DJULIAN@',
+            'd_day'        => 21,
+            'd_mon'        => 12,
+            'd_month'      => 'DEC',
+            'd_year'       => 1799,
+            'd_julianday1' => 2378497,
+            'd_julianday2' => 2378497,
+        ]);
+
+        // Mirror the child-mortality consumer's per-individual collapse.
+        $rows = BirthDeathPairsQuery::for($tree, true)
+            ->groupBy('individuals.i_id')
+            ->select([
+                DateAggregate::min('birth', 'd_type', 'birth_type'),
+                DateAggregate::min('birth', 'd_julianday1', 'birth_jd'),
+                DateAggregate::min('birth', 'd_year', 'birth_year'),
+            ])
+            ->get();
+
+        self::assertCount(1, $rows, 'The tied cross-calendar birth pairs the individual exactly once.');
+
+        $row = $rows[0];
+
+        self::assertSame(
+            '@#DGREGORIAN@',
+            RowCast::string($row, 'birth_type'),
+            'The Gregorian calendar wins the deterministic tie-break (G < J).',
+        );
+        self::assertSame(
+            1800,
+            RowCast::int($row, 'birth_year'),
+            'The birth year is read from the same row as the type — never the Julian row\'s 1799.',
+        );
+        self::assertSame(
+            1800,
+            GregorianDate::year(
+                RowCast::string($row, 'birth_type'),
+                RowCast::int($row, 'birth_year'),
+                RowCast::int($row, 'birth_jd'),
+            ),
+            'The coherent birth row buckets the cohort into 1800, not the off-by-one 1799.',
+        );
+    }
+}

--- a/tests/Integration/DedupedEventDatesTest.php
+++ b/tests/Integration/DedupedEventDatesTest.php
@@ -252,6 +252,86 @@ final class DedupedEventDatesTest extends IntegrationTestCase
     }
 
     /**
+     * The exact same-julian-day cross-calendar tie whose native years diverge:
+     * a Gregorian `1 JAN 1800` and a Julian `21 DEC 1799` describe the same
+     * physical day (julian day 2378497) but carry diverging Gregorian-scale
+     * native years (1800 vs 1799). Independent column-wise minima would draw the
+     * `d_type` from the Gregorian row (`@#DGREGORIAN@` < `@#DJULIAN@`) but the
+     * `d_year` from the Julian row (1799 < 1800), so the representative would be
+     * the incoherent pair (Gregorian type, year 1799) and bucket the record into
+     * the wrong period — across the 1799/1800 century edge. The representative
+     * must instead be ONE coherent row: the Gregorian row, year 1800.
+     */
+    #[Test]
+    public function resolvesSameJulianDayCrossCalendarTieToOneCoherentRow(): void
+    {
+        $tree = $this->importFixtureTree('deduped-event-dates.ged');
+
+        // Both rows share the exact lower-bound julian day (Gregorian 1 JAN
+        // 1800 = 2378497), so neither wins the MIN(d_julianday1) pin — the tie
+        // is decided downstream. Their native Gregorian-scale years differ by
+        // one, and the row that wins the type minimum (Gregorian) carries the
+        // HIGHER year, so a column-wise MIN(d_year) would cross-contaminate it.
+        DB::table('dates')->insert([
+            'd_gid'        => 'I9',
+            'd_file'       => $tree->id(),
+            'd_fact'       => 'BIRT',
+            'd_type'       => '@#DGREGORIAN@',
+            'd_day'        => 1,
+            'd_mon'        => 1,
+            'd_month'      => 'JAN',
+            'd_year'       => 1800,
+            'd_julianday1' => 2378497,
+            'd_julianday2' => 2378497,
+        ]);
+        DB::table('dates')->insert([
+            'd_gid'        => 'I9',
+            'd_file'       => $tree->id(),
+            'd_fact'       => 'BIRT',
+            'd_type'       => '@#DJULIAN@',
+            'd_day'        => 21,
+            'd_mon'        => 12,
+            'd_month'      => 'DEC',
+            'd_year'       => 1799,
+            'd_julianday1' => 2378497,
+            'd_julianday2' => 2378497,
+        ]);
+
+        $row = null;
+
+        foreach (DedupedEventDates::query($tree, 'BIRT')->get() as $candidate) {
+            if (RowCast::string($candidate, 'd_gid') === 'I9') {
+                $row = $candidate;
+
+                break;
+            }
+        }
+
+        self::assertNotNull($row, 'The tied cross-calendar birth surfaces as a single representative row.');
+        self::assertSame(
+            '@#DGREGORIAN@',
+            RowCast::string($row, 'd_type'),
+            'The Gregorian calendar wins the deterministic tie-break (G < J).',
+        );
+        self::assertSame(
+            1800,
+            RowCast::int($row, 'd_year'),
+            'The year is read from the same row as the type — never the Julian row\'s 1799.',
+        );
+        self::assertSame(1, RowCast::int($row, 'd_mon'), 'Month comes from the chosen Gregorian row.');
+        self::assertSame(1, RowCast::int($row, 'd_day'), 'Day comes from the chosen Gregorian row.');
+        self::assertSame(
+            1800,
+            GregorianDate::year(
+                RowCast::string($row, 'd_type'),
+                RowCast::int($row, 'd_year'),
+                RowCast::int($row, 'd_julianday1'),
+            ),
+            'The coherent representative buckets the record into 1800, not the off-by-one 1799.',
+        );
+    }
+
+    /**
      * Build a `dates` row sharing I1's birth julian day (2415021) for the
      * tie-collapse test, parameterised by the columns the outer filters guard.
      *

--- a/tests/fixtures/birth-death-pairs-cross-calendar-tie.ged
+++ b/tests/fixtures/birth-death-pairs-cross-calendar-tie.ged
@@ -1,0 +1,17 @@
+0 HEAD
+1 SOUR webtrees-statistics-fixture
+2 NAME birth-death-pairs-cross-calendar-tie
+1 DEST ANSTFILE
+1 CHAR UTF-8
+1 SUBM @SUBM1@
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+0 @SUBM1@ SUBM
+1 NAME Fixture
+0 @I1@ INDI
+1 NAME Tie /CrossCal/
+1 SEX M
+1 DEAT
+2 DATE 1 JAN 1803
+0 TRLR


### PR DESCRIPTION
Closes #137.

## Problem

The date-bucketing helpers resolve a record's representative event by the minimum julian day, then read the bucket inputs `d_type` / `d_year` / `d_mon` / `d_day` as independent column-wise `MIN()` aggregates. When two same-fact rows of one record share the **exact same** `d_julianday1` but belong to **different calendars whose native years differ** — a Gregorian `1 JAN 1800` and a Julian `21 DEC 1799` transcription of the same physical day (both julian day 2378497, native years 1800 vs 1799) — the column minima are drawn from different tied rows: `MIN(d_type)` picks the Gregorian row while `MIN(d_year)` picks the Julian row's lower year. The representative becomes the incoherent pair *(Gregorian type, year 1799)* and the record buckets one year — and at a decade/century edge one bucket — off.

Cardinality (exact-once counting) was never affected; only the bucket year could shift.

## Fix

Pick the representative as a **single deterministically tie-broken row**: among the rows sharing the lower-bound julian day, pin the lexicographically smallest `d_type`, then read every exposed column from that one calendar.

- A Gregorian/Julian tie resolves to the Gregorian row (`@#DGREGORIAN@` < `@#DJULIAN@`); a Gregorian-scale winner keeps its native year — the value webtrees core itself buckets by.
- Any other calendar converts the *shared* julian day through `GregorianDate`, so the single deterministic winner always lands in the correct Gregorian period.

Applied to both representative sites:

- **`DedupedEventDates`** (the dedup chokepoint feeding the century / decade / month / zodiac / name-passdown cards) — adds an intermediate tie-break subquery and pins the final join on `(d_gid, min_jd, rep_type)`.
- **`BirthDeathPairsQuery`** (child-mortality and lifespan-by-century) — carries the tie-break `rep_type` through `lowerBoundBirth` and pins the birth alias on `birth.d_type = birth_rep.rep_type`.

The new intermediate `GROUP BY`s select only the grouping key plus aggregates, so they stay `ONLY_FULL_GROUP_BY`-safe on the MySQL CI lane.

## Tests

Discriminator integration tests inject the exact same-julian-day cross-calendar tie (Gregorian 1800 + Julian 1799 sharing julian day 2378497) and assert the representative is the coherent Gregorian row (year 1800), not the off-by-one 1799 — confirmed RED before the fix, GREEN after. Full `composer ci:test` green (665 tests).

## Follow-up

The review surfaced the same per-column-`MIN()` representative class in two **untouched** `ChildrenRepository` methods (`multipleBirthRateByCentury`, `firstChildBirthMonthByFamily`) — tracked separately in #150 to keep this change scoped to its two named helpers.
