### PR TITLE
GH-154: Fix two slow statistics cards (generation-depth N+1, given-name double fold)

### DIFF
--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -103,7 +103,7 @@ msgstr "%1$s let (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s z %3$s dětí zemřelo před 5. rokem"
 
-#: src/Repository/NameRepository.php:669
+#: src/Repository/NameRepository.php:676
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -114,7 +114,7 @@ msgstr "%1$s %% — %2$s z %3$s dcer sdílí alespoň jedno křestní jméno s m
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s z %3$s osob s citovaným zdrojem"
 
-#: src/Repository/NameRepository.php:663
+#: src/Repository/NameRepository.php:670
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1667,7 +1667,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:488
+#: src/Repository/NameRepository.php:495
 msgid "Father → son"
 msgstr "Otec → syn"
 
@@ -2344,7 +2344,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Nejvíce manželství"
 
-#: src/Repository/NameRepository.php:495
+#: src/Repository/NameRepository.php:502
 msgid "Mother → daughter"
 msgstr "Matka → dcera"
 
@@ -3309,7 +3309,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
+#: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -103,7 +103,7 @@ msgstr "%1$s let (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s z %3$s dětí zemřelo před 5. rokem"
 
-#: src/Repository/NameRepository.php:620
+#: src/Repository/NameRepository.php:669
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -114,7 +114,7 @@ msgstr "%1$s %% — %2$s z %3$s dcer sdílí alespoň jedno křestní jméno s m
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s z %3$s osob s citovaným zdrojem"
 
-#: src/Repository/NameRepository.php:614
+#: src/Repository/NameRepository.php:663
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1667,7 +1667,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:439
+#: src/Repository/NameRepository.php:488
 msgid "Father → son"
 msgstr "Otec → syn"
 
@@ -2344,7 +2344,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Nejvíce manželství"
 
-#: src/Repository/NameRepository.php:446
+#: src/Repository/NameRepository.php:495
 msgid "Mother → daughter"
 msgstr "Matka → dcera"
 
@@ -3309,7 +3309,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:603 src/Repository/NameRepository.php:607
+#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -102,7 +102,7 @@ msgstr "%1$s år (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s af %3$s børn døde før 5-årsalderen"
 
-#: src/Repository/NameRepository.php:620
+#: src/Repository/NameRepository.php:669
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -113,7 +113,7 @@ msgstr "%1$s %% — %2$s af %3$s døtre deler mindst ét fornavn med moren"
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s af %3$s personer med kilde"
 
-#: src/Repository/NameRepository.php:614
+#: src/Repository/NameRepository.php:663
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1630,7 +1630,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:439
+#: src/Repository/NameRepository.php:488
 msgid "Father → son"
 msgstr "Far → søn"
 
@@ -2309,7 +2309,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Flest ægtefæller"
 
-#: src/Repository/NameRepository.php:446
+#: src/Repository/NameRepository.php:495
 msgid "Mother → daughter"
 msgstr "Mor → datter"
 
@@ -3273,7 +3273,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:603 src/Repository/NameRepository.php:607
+#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -102,7 +102,7 @@ msgstr "%1$s år (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s af %3$s børn døde før 5-årsalderen"
 
-#: src/Repository/NameRepository.php:669
+#: src/Repository/NameRepository.php:676
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -113,7 +113,7 @@ msgstr "%1$s %% — %2$s af %3$s døtre deler mindst ét fornavn med moren"
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s af %3$s personer med kilde"
 
-#: src/Repository/NameRepository.php:663
+#: src/Repository/NameRepository.php:670
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1630,7 +1630,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:488
+#: src/Repository/NameRepository.php:495
 msgid "Father → son"
 msgstr "Far → søn"
 
@@ -2309,7 +2309,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Flest ægtefæller"
 
-#: src/Repository/NameRepository.php:495
+#: src/Repository/NameRepository.php:502
 msgid "Mother → daughter"
 msgstr "Mor → datter"
 
@@ -3273,7 +3273,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
+#: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -103,7 +103,7 @@ msgstr "%1$s Jahre (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s von %3$s Kindern starben vor dem 5. Lebensjahr"
 
-#: src/Repository/NameRepository.php:620
+#: src/Repository/NameRepository.php:669
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -115,7 +115,7 @@ msgstr ""
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s von %3$s Personen mit Quelle"
 
-#: src/Repository/NameRepository.php:614
+#: src/Repository/NameRepository.php:663
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1743,7 +1743,7 @@ msgstr "Hungersnot in Ostfrankreich (1650–1652)"
 msgid "Famine of 1693–1694"
 msgstr "Hungersnot von 1693–1694"
 
-#: src/Repository/NameRepository.php:439
+#: src/Repository/NameRepository.php:488
 msgid "Father → son"
 msgstr "Vater → Sohn"
 
@@ -2470,7 +2470,7 @@ msgstr "Meiste Kinder"
 msgid "Most spouses"
 msgstr "Meiste Ehepartner"
 
-#: src/Repository/NameRepository.php:446
+#: src/Repository/NameRepository.php:495
 msgid "Mother → daughter"
 msgstr "Mutter → Tochter"
 
@@ -3496,7 +3496,7 @@ msgstr "neun"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:603 src/Repository/NameRepository.php:607
+#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -103,7 +103,7 @@ msgstr "%1$s Jahre (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s von %3$s Kindern starben vor dem 5. Lebensjahr"
 
-#: src/Repository/NameRepository.php:669
+#: src/Repository/NameRepository.php:676
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -115,7 +115,7 @@ msgstr ""
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s von %3$s Personen mit Quelle"
 
-#: src/Repository/NameRepository.php:663
+#: src/Repository/NameRepository.php:670
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1743,7 +1743,7 @@ msgstr "Hungersnot in Ostfrankreich (1650–1652)"
 msgid "Famine of 1693–1694"
 msgstr "Hungersnot von 1693–1694"
 
-#: src/Repository/NameRepository.php:488
+#: src/Repository/NameRepository.php:495
 msgid "Father → son"
 msgstr "Vater → Sohn"
 
@@ -2470,7 +2470,7 @@ msgstr "Meiste Kinder"
 msgid "Most spouses"
 msgstr "Meiste Ehepartner"
 
-#: src/Repository/NameRepository.php:495
+#: src/Repository/NameRepository.php:502
 msgid "Mother → daughter"
 msgstr "Mutter → Tochter"
 
@@ -3496,7 +3496,7 @@ msgstr "neun"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
+#: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -102,7 +102,7 @@ msgstr "%1$s years (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s of %3$s children died before age 5"
 
-#: src/Repository/NameRepository.php:669
+#: src/Repository/NameRepository.php:676
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -113,7 +113,7 @@ msgstr ""
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s%% — %2$s of %3$s individuals sourced"
 
-#: src/Repository/NameRepository.php:663
+#: src/Repository/NameRepository.php:670
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1631,7 +1631,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:488
+#: src/Repository/NameRepository.php:495
 msgid "Father → son"
 msgstr "Father → son"
 
@@ -2297,7 +2297,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Most spouses"
 
-#: src/Repository/NameRepository.php:495
+#: src/Repository/NameRepository.php:502
 msgid "Mother → daughter"
 msgstr ""
 
@@ -3261,7 +3261,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
+#: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -102,7 +102,7 @@ msgstr "%1$s years (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s of %3$s children died before age 5"
 
-#: src/Repository/NameRepository.php:620
+#: src/Repository/NameRepository.php:669
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -113,7 +113,7 @@ msgstr ""
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s%% — %2$s of %3$s individuals sourced"
 
-#: src/Repository/NameRepository.php:614
+#: src/Repository/NameRepository.php:663
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1631,7 +1631,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:439
+#: src/Repository/NameRepository.php:488
 msgid "Father → son"
 msgstr "Father → son"
 
@@ -2297,7 +2297,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Most spouses"
 
-#: src/Repository/NameRepository.php:446
+#: src/Repository/NameRepository.php:495
 msgid "Mother → daughter"
 msgstr ""
 
@@ -3261,7 +3261,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:603 src/Repository/NameRepository.php:607
+#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -103,7 +103,7 @@ msgstr "%1$s ans (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s sur %3$s enfants décédés avant 5 ans"
 
-#: src/Repository/NameRepository.php:669
+#: src/Repository/NameRepository.php:676
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -115,7 +115,7 @@ msgstr ""
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s sur %3$s individus avec source"
 
-#: src/Repository/NameRepository.php:663
+#: src/Repository/NameRepository.php:670
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1639,7 +1639,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:488
+#: src/Repository/NameRepository.php:495
 msgid "Father → son"
 msgstr "Père → fils"
 
@@ -2325,7 +2325,7 @@ msgstr "Plus d'enfants"
 msgid "Most spouses"
 msgstr "Plus d'époux"
 
-#: src/Repository/NameRepository.php:495
+#: src/Repository/NameRepository.php:502
 msgid "Mother → daughter"
 msgstr "Mère → fille"
 
@@ -3299,7 +3299,7 @@ msgstr "neuf"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
+#: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -103,7 +103,7 @@ msgstr "%1$s ans (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s sur %3$s enfants décédés avant 5 ans"
 
-#: src/Repository/NameRepository.php:620
+#: src/Repository/NameRepository.php:669
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -115,7 +115,7 @@ msgstr ""
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s sur %3$s individus avec source"
 
-#: src/Repository/NameRepository.php:614
+#: src/Repository/NameRepository.php:663
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1639,7 +1639,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:439
+#: src/Repository/NameRepository.php:488
 msgid "Father → son"
 msgstr "Père → fils"
 
@@ -2325,7 +2325,7 @@ msgstr "Plus d'enfants"
 msgid "Most spouses"
 msgstr "Plus d'époux"
 
-#: src/Repository/NameRepository.php:446
+#: src/Repository/NameRepository.php:495
 msgid "Mother → daughter"
 msgstr "Mère → fille"
 
@@ -3299,7 +3299,7 @@ msgstr "neuf"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:603 src/Repository/NameRepository.php:607
+#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/it/messages.po
+++ b/resources/lang/it/messages.po
@@ -103,7 +103,7 @@ msgstr "%1$s anni (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s di %3$s bambini sono morti prima dei 5 anni"
 
-#: src/Repository/NameRepository.php:620
+#: src/Repository/NameRepository.php:669
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -114,7 +114,7 @@ msgstr "%1$s %% — %2$s di %3$s figlie condividono almeno un nome con la madre"
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s su %3$s individui con fonte"
 
-#: src/Repository/NameRepository.php:614
+#: src/Repository/NameRepository.php:663
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:439
+#: src/Repository/NameRepository.php:488
 msgid "Father → son"
 msgstr "Padre → figlio"
 
@@ -2325,7 +2325,7 @@ msgstr "Più figli"
 msgid "Most spouses"
 msgstr "Maggior numero di coniugi"
 
-#: src/Repository/NameRepository.php:446
+#: src/Repository/NameRepository.php:495
 msgid "Mother → daughter"
 msgstr "Madre → figlia"
 
@@ -3296,7 +3296,7 @@ msgstr "nove"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:603 src/Repository/NameRepository.php:607
+#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/it/messages.po
+++ b/resources/lang/it/messages.po
@@ -103,7 +103,7 @@ msgstr "%1$s anni (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s di %3$s bambini sono morti prima dei 5 anni"
 
-#: src/Repository/NameRepository.php:669
+#: src/Repository/NameRepository.php:676
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -114,7 +114,7 @@ msgstr "%1$s %% — %2$s di %3$s figlie condividono almeno un nome con la madre"
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s su %3$s individui con fonte"
 
-#: src/Repository/NameRepository.php:663
+#: src/Repository/NameRepository.php:670
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:488
+#: src/Repository/NameRepository.php:495
 msgid "Father → son"
 msgstr "Padre → figlio"
 
@@ -2325,7 +2325,7 @@ msgstr "Più figli"
 msgid "Most spouses"
 msgstr "Maggior numero di coniugi"
 
-#: src/Repository/NameRepository.php:495
+#: src/Repository/NameRepository.php:502
 msgid "Mother → daughter"
 msgstr "Madre → figlia"
 
@@ -3296,7 +3296,7 @@ msgstr "nove"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
+#: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -102,7 +102,7 @@ msgstr "%1$s år (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s av %3$s barn døde før 5-årsalderen"
 
-#: src/Repository/NameRepository.php:620
+#: src/Repository/NameRepository.php:669
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -113,7 +113,7 @@ msgstr "%1$s %% — %2$s av %3$s døtre deler minst ett fornavn med moren"
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s av %3$s personer med kilde"
 
-#: src/Repository/NameRepository.php:614
+#: src/Repository/NameRepository.php:663
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1629,7 +1629,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:439
+#: src/Repository/NameRepository.php:488
 msgid "Father → son"
 msgstr "Far → sønn"
 
@@ -2308,7 +2308,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Flest ektefeller"
 
-#: src/Repository/NameRepository.php:446
+#: src/Repository/NameRepository.php:495
 msgid "Mother → daughter"
 msgstr "Mor → datter"
 
@@ -3272,7 +3272,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:603 src/Repository/NameRepository.php:607
+#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -102,7 +102,7 @@ msgstr "%1$s år (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s av %3$s barn døde før 5-årsalderen"
 
-#: src/Repository/NameRepository.php:669
+#: src/Repository/NameRepository.php:676
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -113,7 +113,7 @@ msgstr "%1$s %% — %2$s av %3$s døtre deler minst ett fornavn med moren"
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s av %3$s personer med kilde"
 
-#: src/Repository/NameRepository.php:663
+#: src/Repository/NameRepository.php:670
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1629,7 +1629,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:488
+#: src/Repository/NameRepository.php:495
 msgid "Father → son"
 msgstr "Far → sønn"
 
@@ -2308,7 +2308,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Flest ektefeller"
 
-#: src/Repository/NameRepository.php:495
+#: src/Repository/NameRepository.php:502
 msgid "Mother → daughter"
 msgstr "Mor → datter"
 
@@ -3272,7 +3272,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
+#: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -103,7 +103,7 @@ msgstr "%1$s jaar (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s van %3$s kinderen overleden vóór de leeftijd van 5 jaar"
 
-#: src/Repository/NameRepository.php:669
+#: src/Repository/NameRepository.php:676
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -115,7 +115,7 @@ msgstr ""
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s van %3$s personen met bron"
 
-#: src/Repository/NameRepository.php:663
+#: src/Repository/NameRepository.php:670
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1756,7 +1756,7 @@ msgstr "Hongersnood in Oost-Frankrijk (1650–1652)"
 msgid "Famine of 1693–1694"
 msgstr "Hongersnood van 1693–1694"
 
-#: src/Repository/NameRepository.php:488
+#: src/Repository/NameRepository.php:495
 msgid "Father → son"
 msgstr "Vader → zoon"
 
@@ -2490,7 +2490,7 @@ msgstr "Meeste kinderen"
 msgid "Most spouses"
 msgstr "Meeste echtgenoten"
 
-#: src/Repository/NameRepository.php:495
+#: src/Repository/NameRepository.php:502
 msgid "Mother → daughter"
 msgstr "Moeder → dochter"
 
@@ -3524,7 +3524,7 @@ msgstr "negen"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
+#: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -103,7 +103,7 @@ msgstr "%1$s jaar (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s van %3$s kinderen overleden vóór de leeftijd van 5 jaar"
 
-#: src/Repository/NameRepository.php:620
+#: src/Repository/NameRepository.php:669
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -115,7 +115,7 @@ msgstr ""
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s van %3$s personen met bron"
 
-#: src/Repository/NameRepository.php:614
+#: src/Repository/NameRepository.php:663
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1756,7 +1756,7 @@ msgstr "Hongersnood in Oost-Frankrijk (1650–1652)"
 msgid "Famine of 1693–1694"
 msgstr "Hongersnood van 1693–1694"
 
-#: src/Repository/NameRepository.php:439
+#: src/Repository/NameRepository.php:488
 msgid "Father → son"
 msgstr "Vader → zoon"
 
@@ -2490,7 +2490,7 @@ msgstr "Meeste kinderen"
 msgid "Most spouses"
 msgstr "Meeste echtgenoten"
 
-#: src/Repository/NameRepository.php:446
+#: src/Repository/NameRepository.php:495
 msgid "Mother → daughter"
 msgstr "Moeder → dochter"
 
@@ -3524,7 +3524,7 @@ msgstr "negen"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:603 src/Repository/NameRepository.php:607
+#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/pl/messages.po
+++ b/resources/lang/pl/messages.po
@@ -104,7 +104,7 @@ msgstr "%1$s lat (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s z %3$s dzieci zmarło przed 5 rokiem życia"
 
-#: src/Repository/NameRepository.php:669
+#: src/Repository/NameRepository.php:676
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -115,7 +115,7 @@ msgstr "%1$s %% — %2$s z %3$s córek dzieli co najmniej jedno imię z matką"
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s z %3$s osób ze źródłem"
 
-#: src/Repository/NameRepository.php:663
+#: src/Repository/NameRepository.php:670
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:488
+#: src/Repository/NameRepository.php:495
 msgid "Father → son"
 msgstr "Ojciec → syn"
 
@@ -2344,7 +2344,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Najwięcej współmałżonków"
 
-#: src/Repository/NameRepository.php:495
+#: src/Repository/NameRepository.php:502
 msgid "Mother → daughter"
 msgstr "Matka → córka"
 
@@ -3312,7 +3312,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
+#: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/pl/messages.po
+++ b/resources/lang/pl/messages.po
@@ -104,7 +104,7 @@ msgstr "%1$s lat (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s z %3$s dzieci zmarło przed 5 rokiem życia"
 
-#: src/Repository/NameRepository.php:620
+#: src/Repository/NameRepository.php:669
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -115,7 +115,7 @@ msgstr "%1$s %% — %2$s z %3$s córek dzieli co najmniej jedno imię z matką"
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s z %3$s osób ze źródłem"
 
-#: src/Repository/NameRepository.php:614
+#: src/Repository/NameRepository.php:663
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:439
+#: src/Repository/NameRepository.php:488
 msgid "Father → son"
 msgstr "Ojciec → syn"
 
@@ -2344,7 +2344,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Najwięcej współmałżonków"
 
-#: src/Repository/NameRepository.php:446
+#: src/Repository/NameRepository.php:495
 msgid "Mother → daughter"
 msgstr "Matka → córka"
 
@@ -3312,7 +3312,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:603 src/Repository/NameRepository.php:607
+#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -104,7 +104,7 @@ msgstr "%1$s лет (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s из %3$s детей умерло до 5 лет"
 
-#: src/Repository/NameRepository.php:620
+#: src/Repository/NameRepository.php:669
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -115,7 +115,7 @@ msgstr "%1$s %% — %2$s из %3$s дочерей разделяют хотя б
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s из %3$s человек с источником"
 
-#: src/Repository/NameRepository.php:614
+#: src/Repository/NameRepository.php:663
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:439
+#: src/Repository/NameRepository.php:488
 msgid "Father → son"
 msgstr "Отец → сын"
 
@@ -2356,7 +2356,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Больше всего супругов"
 
-#: src/Repository/NameRepository.php:446
+#: src/Repository/NameRepository.php:495
 msgid "Mother → daughter"
 msgstr "Мать → дочь"
 
@@ -3321,7 +3321,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:603 src/Repository/NameRepository.php:607
+#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -104,7 +104,7 @@ msgstr "%1$s лет (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s из %3$s детей умерло до 5 лет"
 
-#: src/Repository/NameRepository.php:669
+#: src/Repository/NameRepository.php:676
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -115,7 +115,7 @@ msgstr "%1$s %% — %2$s из %3$s дочерей разделяют хотя б
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s %% — %2$s из %3$s человек с источником"
 
-#: src/Repository/NameRepository.php:663
+#: src/Repository/NameRepository.php:670
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:488
+#: src/Repository/NameRepository.php:495
 msgid "Father → son"
 msgstr "Отец → сын"
 
@@ -2356,7 +2356,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "Больше всего супругов"
 
-#: src/Repository/NameRepository.php:495
+#: src/Repository/NameRepository.php:502
 msgid "Mother → daughter"
 msgstr "Мать → дочь"
 
@@ -3321,7 +3321,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
+#: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -98,7 +98,7 @@ msgstr "%1$s 年 (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s/%3$s 名儿童在 5 岁前去世"
 
-#: src/Repository/NameRepository.php:620
+#: src/Repository/NameRepository.php:669
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -109,7 +109,7 @@ msgstr "%1$s %% — %3$s 位女儿中有 %2$s 位与母亲至少共享一个名�
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s%% — %3$s 人中有 %2$s 人有来源"
 
-#: src/Repository/NameRepository.php:614
+#: src/Repository/NameRepository.php:663
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1609,7 +1609,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:439
+#: src/Repository/NameRepository.php:488
 msgid "Father → son"
 msgstr "父亲 → 儿子"
 
@@ -2277,7 +2277,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "最多配偶"
 
-#: src/Repository/NameRepository.php:446
+#: src/Repository/NameRepository.php:495
 msgid "Mother → daughter"
 msgstr "母亲 → 女儿"
 
@@ -3234,7 +3234,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:603 src/Repository/NameRepository.php:607
+#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -98,7 +98,7 @@ msgstr "%1$s 年 (n = %2$s)"
 msgid "%1$s%% — %2$s of %3$s children died before age 5"
 msgstr "%1$s%% — %2$s/%3$s 名儿童在 5 岁前去世"
 
-#: src/Repository/NameRepository.php:669
+#: src/Repository/NameRepository.php:676
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s daughters share at least one given name with the mother"
@@ -109,7 +109,7 @@ msgstr "%1$s %% — %3$s 位女儿中有 %2$s 位与母亲至少共享一个名�
 msgid "%1$s%% — %2$s of %3$s individuals sourced"
 msgstr "%1$s%% — %3$s 人中有 %2$s 人有来源"
 
-#: src/Repository/NameRepository.php:663
+#: src/Repository/NameRepository.php:670
 #, php-format
 msgid ""
 "%1$s%% — %2$s of %3$s sons share at least one given name with the father"
@@ -1609,7 +1609,7 @@ msgstr ""
 msgid "Famine of 1693–1694"
 msgstr ""
 
-#: src/Repository/NameRepository.php:488
+#: src/Repository/NameRepository.php:495
 msgid "Father → son"
 msgstr "父亲 → 儿子"
 
@@ -2277,7 +2277,7 @@ msgstr "Most children"
 msgid "Most spouses"
 msgstr "最多配偶"
 
-#: src/Repository/NameRepository.php:495
+#: src/Repository/NameRepository.php:502
 msgid "Mother → daughter"
 msgstr "母亲 → 女儿"
 
@@ -3234,7 +3234,7 @@ msgstr "nine"
 
 #: src/Repository/LifeSpanRepository.php:816
 #: src/Repository/LifeSpanRepository.php:823
-#: src/Repository/NameRepository.php:652 src/Repository/NameRepository.php:656
+#: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378
 #, php-format

--- a/src/Repository/GenerationDepthRepository.php
+++ b/src/Repository/GenerationDepthRepository.php
@@ -28,6 +28,7 @@ use function array_map;
 use function array_merge;
 use function array_pop;
 use function array_slice;
+use function array_unique;
 use function array_values;
 use function count;
 use function max;
@@ -127,8 +128,12 @@ final readonly class GenerationDepthRepository
         // issued one `SELECT i_gedcom` per member and grew with the depth
         // (GH-154). Passing the pre-fetched gedcom as the factory's third
         // argument skips that lookup, keeping the resolution a single query.
+        // Flatten every rendered chain and de-duplicate the ids: should more
+        // than one chain ever be rendered, sibling chains share most of their
+        // ancestors, so the union keeps the placeholder count (and the fetched
+        // row set) minimal.
         $gedcomByXref = $this->gedcomByXref(
-            array_merge(...array_values($top)),
+            array_values(array_unique(array_merge(...array_values($top)))),
         );
 
         foreach ($top as $chainIds) {

--- a/src/Repository/GenerationDepthRepository.php
+++ b/src/Repository/GenerationDepthRepository.php
@@ -25,8 +25,10 @@ use MagicSunday\Webtrees\Statistic\Support\Gedcom\RowCast;
 use function array_filter;
 use function array_keys;
 use function array_map;
+use function array_merge;
 use function array_pop;
 use function array_slice;
+use function array_values;
 use function count;
 use function max;
 use function strcmp;
@@ -119,11 +121,21 @@ final readonly class GenerationDepthRepository
         $top    = array_slice($byLeaf, 0, self::MAX_CHAINS_RENDERED, true);
         $chains = [];
 
+        // Resolve every rendered chain member from a single bulk gedcom fetch
+        // rather than one `IndividualFactory::make()` round-trip per id: a deep
+        // lineage chain is `maxDepth + 1` individuals long, so the per-id loop
+        // issued one `SELECT i_gedcom` per member and grew with the depth
+        // (GH-154). Passing the pre-fetched gedcom as the factory's third
+        // argument skips that lookup, keeping the resolution a single query.
+        $gedcomByXref = $this->gedcomByXref(
+            array_merge(...array_values($top)),
+        );
+
         foreach ($top as $chainIds) {
             $resolved = [];
 
             foreach ($chainIds as $id) {
-                $individual = Registry::individualFactory()->make($id, $this->tree);
+                $individual = Registry::individualFactory()->make($id, $this->tree, $gedcomByXref[$id] ?? null);
 
                 if ($individual instanceof Individual) {
                     $resolved[] = $individual;
@@ -371,6 +383,45 @@ final readonly class GenerationDepthRepository
             // Same id can have multiple BIRT date rows; keep the latest.
             $existing = $out[$id] ?? 0;
             $out[$id] = max($existing, $jday);
+        }
+
+        return $out;
+    }
+
+    /**
+     * Bulk-fetch the raw gedcom for every given xref in a single chunked query,
+     * returning an `[xref => gedcom]` map. Lets the chain resolution hand the
+     * gedcom straight to {@see Registry::individualFactory()} instead of issuing
+     * one `SELECT i_gedcom` per chain member — the N+1 the rendered-chain loop
+     * otherwise scaled one query per generation deep (GH-154). {@see
+     * ChunkedWhereIn} keeps the id filter within the placeholder budget on a
+     * pathologically deep lineage.
+     *
+     * @param list<string> $xrefs
+     *
+     * @return array<array-key, string>
+     */
+    private function gedcomByXref(array $xrefs): array
+    {
+        if ($xrefs === []) {
+            return [];
+        }
+
+        $query = TreeScope::table($this->tree, 'individuals')
+            ->select(['i_id', 'i_gedcom']);
+
+        $rows = ChunkedWhereIn::get($query, 'i_id', $xrefs);
+
+        $out = [];
+
+        foreach ($rows as $row) {
+            $id = RowCast::string($row, 'i_id');
+
+            if ($id === '') {
+                continue;
+            }
+
+            $out[$id] = RowCast::string($row, 'i_gedcom');
         }
 
         return $out;

--- a/src/Repository/NameRepository.php
+++ b/src/Repository/NameRepository.php
@@ -31,14 +31,14 @@ use MagicSunday\Webtrees\Statistic\Support\Gedcom\GivenNameNormalizer;
 use MagicSunday\Webtrees\Statistic\Support\Gedcom\RowCast;
 use MagicSunday\Webtrees\Statistic\Support\Locale\CenturyName;
 
+use function array_filter;
 use function array_intersect;
 use function array_keys;
 use function array_map;
+use function count;
 use function ksort;
 use function round;
 use function usort;
-
-use const PHP_INT_MAX;
 
 /**
  * Top-N lists and total counts for surnames and given names. Both the lists
@@ -64,7 +64,7 @@ use const PHP_INT_MAX;
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
  * @link    https://github.com/magicsunday/webtrees-statistics/
  */
-final readonly class NameRepository
+final class NameRepository
 {
     /**
      * Per-century sample floor for {@see sameSexNamePassdownByCentury}.
@@ -98,10 +98,21 @@ final readonly class NameRepository
     public const string SEX_ALL = 'ALL';
 
     /**
+     * Per-sex memo of the tokenised given-name fold — the expensive `name`-table
+     * scan plus per-token tokenise that both the distinct-count card and the
+     * Top-N card consume. Keyed by the sex selector; the threshold and limit are
+     * applied on top of a shared fold, so a tab that renders the count and the
+     * Top-N for the same sex scans the rows once, not once per card (GH-154).
+     *
+     * @var array<string, array{counts: array<string, int>, rawByFold: array<string, array<string, int>>}>
+     */
+    private array $givenNameFoldCache = [];
+
+    /**
      * @param Tree $tree The tree whose names to aggregate
      */
     public function __construct(
-        private Tree $tree,
+        private readonly Tree $tree,
     ) {
     }
 
@@ -213,7 +224,14 @@ final readonly class NameRepository
      */
     public function countDistinctGivenNames(string $sex, int $threshold = 1): int
     {
-        return $this->aggregateGivenNames($sex, $threshold, PHP_INT_MAX)->count();
+        // Count the folded keys that clear the threshold directly off the shared
+        // fold — no Top-N rank/sort is needed for a cardinality, and the fold is
+        // reused by the Top-N card for the same sex (GH-154).
+        $counts = $this->foldGivenNames($sex)['counts'];
+
+        return count(
+            array_filter($counts, static fn (int $count): bool => $count >= $threshold),
+        );
     }
 
     /**
@@ -258,6 +276,10 @@ final readonly class NameRepository
      * not double-counted. Core's `n_type <> '_MARNM'` blacklist is swapped for
      * the whitelist so arbitrary custom sub-tags never reach the tokeniser.
      *
+     * Reads the shared per-sex fold ({@see foldGivenNames}) and applies only the
+     * Top-N rank + threshold filter on top, so the count card and the Top-N card
+     * for the same sex re-use a single `name`-table scan (GH-154).
+     *
      * @param string $sex       GEDCOM sex token — a {@see Sex} case value or {@see SEX_ALL} for every sex
      * @param int    $threshold Lower bound on the individuals a folded name must reach
      * @param int    $limit     Maximum number of folded names to keep, by descending count
@@ -266,6 +288,43 @@ final readonly class NameRepository
      */
     private function aggregateGivenNames(string $sex, int $threshold, int $limit): Collection
     {
+        $fold = $this->foldGivenNames($sex);
+
+        // Order by count descending, then by fold key ascending, before the
+        // limit slice — the shared {@see TopNAggregator::rankKeys()} tie-break
+        // (PHP byte order, independent of the database collation), so the
+        // surviving Top-N is identical across database engines. The dominant raw
+        // spelling of each surviving fold key becomes its display label. The
+        // threshold filter runs after the slice, matching the prior order.
+        $givenNames = TopNAggregator::rank(
+            $fold['counts'],
+            static fn (string $key): string => GivenNameNormalizer::dominantForm($fold['rawByFold'][$key]),
+            $limit,
+        );
+
+        return (new Collection($givenNames))
+            ->filter(static fn (int $count): bool => $count >= $threshold);
+    }
+
+    /**
+     * The expensive half of the given-name aggregation: scan the whitelisted
+     * `name` rows for one sex and fold each individual's tokens into a
+     * `[foldKey => individual count]` map plus a `[foldKey => raw spelling
+     * frequencies]` map for the display label. Memoised per sex selector so the
+     * distinct-count card and the Top-N card for the same sex share one scan
+     * instead of repeating it — the threshold and limit only shape the result
+     * downstream, never the scan (GH-154).
+     *
+     * @param string $sex GEDCOM sex token — a {@see Sex} case value or {@see SEX_ALL} for every sex
+     *
+     * @return array{counts: array<string, int>, rawByFold: array<string, array<string, int>>}
+     */
+    private function foldGivenNames(string $sex): array
+    {
+        if (isset($this->givenNameFoldCache[$sex])) {
+            return $this->givenNameFoldCache[$sex];
+        }
+
         $query = DB::table('name')
             ->where('n_file', '=', $this->tree->id())
             ->whereIn('n_type', self::NAME_TYPE_WHITELIST)
@@ -348,20 +407,10 @@ final readonly class NameRepository
             $countsByKey[$key] = ($countsByKey[$key] ?? 0) + 1;
         }
 
-        // Order by count descending, then by fold key ascending, before the
-        // limit slice — the shared {@see TopNAggregator::rankKeys()} tie-break
-        // (PHP byte order, independent of the database collation), so the
-        // surviving Top-N is identical across database engines. The dominant raw
-        // spelling of each surviving fold key becomes its display label. The
-        // threshold filter runs after the slice, matching the prior order.
-        $givenNames = TopNAggregator::rank(
-            $countsByKey,
-            static fn (string $key): string => GivenNameNormalizer::dominantForm($rawByFold[$key]),
-            $limit,
-        );
-
-        return (new Collection($givenNames))
-            ->filter(static fn (int $count): bool => $count >= $threshold);
+        return $this->givenNameFoldCache[$sex] = [
+            'counts'    => $countsByKey,
+            'rawByFold' => $rawByFold,
+        ];
     }
 
     /**

--- a/src/Repository/NameRepository.php
+++ b/src/Repository/NameRepository.php
@@ -229,6 +229,13 @@ final class NameRepository
         // reused by the Top-N card for the same sex (GH-154).
         $counts = $this->foldGivenNames($sex)['counts'];
 
+        // Every fold key has at least one bearer, so the default threshold of 1
+        // admits all of them — skip the filter scan and closure-per-name on the
+        // hot path (the dashboard always queries with threshold 1).
+        if ($threshold <= 1) {
+            return count($counts);
+        }
+
         return count(
             array_filter($counts, static fn (int $count): bool => $count >= $threshold),
         );

--- a/tests/Integration/GenerationDepthRepositoryIntegrationTest.php
+++ b/tests/Integration/GenerationDepthRepositoryIntegrationTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Webtrees\Statistic\Test\Integration;
 
+use Fisharebest\Webtrees\DB;
 use MagicSunday\Webtrees\Statistic\Model\Ranking\RankingEntry;
 use MagicSunday\Webtrees\Statistic\Model\Tree\GenerationDepthReport;
 use MagicSunday\Webtrees\Statistic\Repository\GenerationDepthRepository;
@@ -25,6 +26,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 
 use function array_map;
 use function array_search;
+use function count;
 
 /**
  * End-to-end test of {@see GenerationDepthRepository} against
@@ -75,6 +77,58 @@ final class GenerationDepthRepositoryIntegrationTest extends IntegrationTestCase
         self::assertSame(
             [0 => 1, 1 => 1, 2 => 1],
             $result->distribution,
+        );
+    }
+
+    /**
+     * The rendered chain must be resolved with a single bulk gedcom fetch, not
+     * one `IndividualFactory::make()` round-trip per chain member (GH-154). On a
+     * deep linear lineage the chain is `maxDepth + 1` individuals long, so a
+     * per-id resolution loop issued one `SELECT i_gedcom` per member and grew
+     * with the lineage depth; the bulk fetch issues a single chunked query
+     * regardless.
+     *
+     * The discriminator is depth-INDEPENDENCE rather than an absolute bound: the
+     * structural scans cost the same number of queries for a three-deep and an
+     * eight-deep lineage, so summary()'s query count must not grow between them.
+     * The old per-id loop made the eight-deep chain cost five extra queries (one
+     * per additional member); the bulk fetch keeps the two equal. This is robust
+     * to an incidental change in the structural query count (a core bump) that a
+     * hard-coded bound would mask.
+     */
+    #[Test]
+    public function summaryResolvesChainWithoutPerMemberQueries(): void
+    {
+        $shallow = $this->importFixtureTree('generation-depth.ged');
+        $deep    = $this->importFixtureTree('generation-depth-deep-chain.ged');
+
+        DB::connection()->flushQueryLog();
+        DB::connection()->enableQueryLog();
+        (new GenerationDepthRepository($shallow, new ParentMapRepository($shallow)))->summary();
+        $shallowQueries = count(DB::connection()->getQueryLog());
+        DB::connection()->disableQueryLog();
+
+        DB::connection()->flushQueryLog();
+        DB::connection()->enableQueryLog();
+        $deepResult  = (new GenerationDepthRepository($deep, new ParentMapRepository($deep)))->summary();
+        $deepQueries = count(DB::connection()->getQueryLog());
+        DB::connection()->disableQueryLog();
+
+        // The deep lineage is eight individuals deep, so the rendered chain holds
+        // all eight — proving the chain was actually reconstructed and resolved,
+        // so the query-count assertion cannot pass on a short-circuited chain.
+        self::assertSame(7, $deepResult->maxDepth);
+        self::assertCount(1, $deepResult->chains);
+        self::assertCount(8, $deepResult->chains[0]);
+        self::assertStringContainsString('Ancestor1', $deepResult->chains[0][0]->fullName());
+        self::assertStringContainsString('Leaf8', $deepResult->chains[0][7]->fullName());
+
+        // The eight-deep chain must not cost more queries than the three-deep
+        // one — chain resolution does not scale one query per chain member.
+        self::assertLessThanOrEqual(
+            $shallowQueries,
+            $deepQueries,
+            'Chain resolution must not scale one query per chain member',
         );
     }
 

--- a/tests/Integration/NameRepositoryIntegrationTest.php
+++ b/tests/Integration/NameRepositoryIntegrationTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Webtrees\Statistic\Test\Integration;
 
+use Fisharebest\Webtrees\DB;
 use Fisharebest\Webtrees\Tree;
 use MagicSunday\Webtrees\Statistic\Enum\Sex;
 use MagicSunday\Webtrees\Statistic\Model\LineChart\LineChartPayload;
@@ -28,6 +29,9 @@ use PHPUnit\Framework\Attributes\UsesClass;
 
 use function array_column;
 use function array_unique;
+use function count;
+
+use const PHP_INT_MAX;
 
 /**
  * Integration test for {@see NameRepository}. The count / passdown cases use
@@ -94,10 +98,11 @@ final class NameRepositoryIntegrationTest extends IntegrationTestCase
     }
 
     /**
-     * Five distinct given names appear in the fixture (Anna, Friedrich, Maria,
-     * Hans, Lisa), split across sexes. Female: Anna×3, Maria×2, Lisa×1 → 3
-     * distinct. Male: Friedrich×2, Hans×3 → 2 distinct. The 12th individual is
-     * undated but still has a given name so still contributes.
+     * Six distinct given names appear in the fixture (Anna, Friedrich, Maria,
+     * Hans, Lisa, plus the sex-`U` 12th individual's "Unknown"), split across
+     * sexes. Female: Anna×3, Maria×2, Lisa×1 → 3 distinct. Male: Friedrich×2,
+     * Hans×3 → 2 distinct. The 12th individual carries sex `U`, so it contributes
+     * to the all-sexes count but to neither the female nor the male count.
      */
     #[Test]
     public function countDistinctGivenNamesPerSex(): void
@@ -111,8 +116,13 @@ final class NameRepositoryIntegrationTest extends IntegrationTestCase
 
     /**
      * The threshold filter excludes given names that occur fewer times than the
-     * threshold. Asking for names that appear at least 3 times across the
-     * fixture should drop the count.
+     * threshold, with the boundary INCLUSIVE (`count >= threshold`). Across all
+     * sexes the fixture carries six distinct given names — Anna (×3), Friedrich
+     * (×2), Maria (×2), Hans (×3), Lisa (×1) and the sex-`U` individual's
+     * "Unknown" (×1) — of which exactly two, Anna and Hans, reach an occurrence
+     * of three. Pinning both exact values guards the inclusive boundary: a
+     * regression to a strict `count > threshold` would drop the two names
+     * sitting exactly on the threshold and yield 0, not 2.
      */
     #[Test]
     public function countDistinctGivenNamesRespectsThreshold(): void
@@ -120,12 +130,69 @@ final class NameRepositoryIntegrationTest extends IntegrationTestCase
         $tree = $this->importFixtureTree('name-trends.ged');
         $repo = $this->repository($tree);
 
-        // With threshold 1 we see all five given names; with
-        // threshold 3 only Anna (3) and Hans (3) qualify.
         $unbounded = $repo->countDistinctGivenNames(NameRepository::SEX_ALL, 1);
         $threeOnly = $repo->countDistinctGivenNames(NameRepository::SEX_ALL, 3);
 
-        self::assertGreaterThan($threeOnly, $unbounded);
+        self::assertSame(6, $unbounded, 'All six distinct given names clear threshold 1');
+        self::assertSame(2, $threeOnly, 'Only Anna (×3) and Hans (×3) reach the inclusive threshold 3');
+    }
+
+    /**
+     * The distinct-count card and the Top-N card for the SAME sex must fold the
+     * underlying `name` rows exactly once between them, not once per card
+     * (GH-154). The fold (the SQL scan plus the per-token tokenise) depends only
+     * on the sex filter; the threshold and limit are applied afterwards, so a
+     * second card for the same sex must reuse the memoised fold rather than
+     * re-scanning. The query count is the discriminator: before the shared fold
+     * the two calls issued two scans, after it a single one.
+     */
+    #[Test]
+    public function givenNameCountAndTopShareOneFoldPerSex(): void
+    {
+        $tree = $this->importFixtureTree('name-trends.ged');
+        $repo = $this->repository($tree);
+
+        DB::connection()->flushQueryLog();
+        DB::connection()->enableQueryLog();
+
+        $repo->countDistinctGivenNames(Sex::Male->value);
+        $repo->topGivenNames(Sex::Male->value, 1, 15);
+
+        $queryCount = count(DB::connection()->getQueryLog());
+
+        DB::connection()->disableQueryLog();
+
+        self::assertSame(
+            1,
+            $queryCount,
+            'Count and Top for one sex must share a single name-row fold, not scan once per card',
+        );
+    }
+
+    /**
+     * The headline distinct-given-name count must stay in lockstep with the
+     * Top-N aggregation it summarises: at a given threshold the count equals the
+     * number of distinct Top-N entries the same threshold yields (GH-154 splits
+     * the count off the shared fold, so this pins that the two derive the same
+     * key set). Asserted symmetrically for both sexes so neither the male nor the
+     * female card can drift.
+     */
+    #[Test]
+    public function givenNameCountMatchesTopNCardinalityForBothSexes(): void
+    {
+        $tree = $this->importFixtureTree('name-trends.ged');
+        $repo = $this->repository($tree);
+
+        foreach ([Sex::Male->value, Sex::Female->value, NameRepository::SEX_ALL] as $sex) {
+            $count = $repo->countDistinctGivenNames($sex, 1);
+            $top   = $repo->topGivenNames($sex, 1, PHP_INT_MAX);
+
+            self::assertCount(
+                $count,
+                $top,
+                'Distinct count must equal the unbounded Top-N cardinality for sex ' . $sex,
+            );
+        }
     }
 
     /**

--- a/tests/fixtures/generation-depth-deep-chain.ged
+++ b/tests/fixtures/generation-depth-deep-chain.ged
@@ -1,0 +1,73 @@
+0 HEAD
+1 SOUR webtrees-statistics-fixture
+2 NAME generation-depth-deep-chain
+1 DEST ANSTFILE
+1 CHAR UTF-8
+1 SUBM @SUBM1@
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+0 @SUBM1@ SUBM
+1 NAME Fixture
+0 @I1@ INDI
+1 NAME Ancestor1 /Chain/
+1 SEX M
+1 FAMS @F1@
+0 @I2@ INDI
+1 NAME Ancestor2 /Chain/
+1 SEX M
+1 FAMC @F1@
+1 FAMS @F2@
+0 @I3@ INDI
+1 NAME Ancestor3 /Chain/
+1 SEX M
+1 FAMC @F2@
+1 FAMS @F3@
+0 @I4@ INDI
+1 NAME Ancestor4 /Chain/
+1 SEX M
+1 FAMC @F3@
+1 FAMS @F4@
+0 @I5@ INDI
+1 NAME Ancestor5 /Chain/
+1 SEX M
+1 FAMC @F4@
+1 FAMS @F5@
+0 @I6@ INDI
+1 NAME Ancestor6 /Chain/
+1 SEX M
+1 FAMC @F5@
+1 FAMS @F6@
+0 @I7@ INDI
+1 NAME Ancestor7 /Chain/
+1 SEX M
+1 FAMC @F6@
+1 FAMS @F7@
+0 @I8@ INDI
+1 NAME Leaf8 /Chain/
+1 SEX M
+1 FAMC @F7@
+1 BIRT
+2 DATE 1 JAN 1900
+0 @F1@ FAM
+1 HUSB @I1@
+1 CHIL @I2@
+0 @F2@ FAM
+1 HUSB @I2@
+1 CHIL @I3@
+0 @F3@ FAM
+1 HUSB @I3@
+1 CHIL @I4@
+0 @F4@ FAM
+1 HUSB @I4@
+1 CHIL @I5@
+0 @F5@ FAM
+1 HUSB @I5@
+1 CHIL @I6@
+0 @F6@ FAM
+1 HUSB @I6@
+1 CHIL @I7@
+0 @F7@ FAM
+1 HUSB @I7@
+1 CHIL @I8@
+0 TRLR


### PR DESCRIPTION
## What

Two pre-existing performance defects on the statistics dashboard, surfaced by profiling against a large live tree (~4.7k individuals) with `dev/profile-tabs.php`. Both are output-preserving — only the query count / wall-clock changes.

### Card 1 — `getGenerationDepthSummary`: N+1 chain resolution (Tree-health tab)
The summary renders one ancestor chain that is `maxDepth + 1` individuals long. Each member was resolved with `IndividualFactory::make()`, issuing **one `SELECT i_gedcom` per member** — a query count that grows with the lineage depth.

**Fix:** bulk-fetch the chain's gedcom once via `ChunkedWhereIn` and pass it as the factory's third argument.

| | queries |
|---|---|
| before | 105 |
| after | 5 |

### Card 3 — given-name count + Top-N: redundant double fold (Names tab)
The distinct-given-name count card and the Top-N list card folded the **same** `name` rows independently — twice per sex, four scans per tab render — because `countDistinctGivenNames()` ran the full tokenise-and-fold aggregation with an unbounded limit only to `count()` it. The scan depends solely on the sex; the threshold and limit only shape the result downstream. The cost is symmetric across both sexes (profiling just happened to surface the male count card as the slowest single hit).

**Fix:** extract the scan + per-token fold into a per-sex memoised `foldGivenNames()`; the count card counts the qualifying fold keys directly, the Top-N card reuses the same fold.

| card | before | after |
|---|---|---|
| male given-name count | 163 ms / 1 q | 63 ms / 1 q |
| male Top-N | 51 ms / 1 q | **5 ms / 0 q** |
| female given-name count | 27 ms / 1 q | 24 ms / 1 q |
| female Top-N | 33 ms / 1 q | **2 ms / 0 q** |
| **Names tab total** | **497 ms** | **322 ms** |

`NameRepository` loses its class-level `readonly` to hold the memo (mirroring `ParentMapRepository`); the `Tree` dependency stays `readonly`.

## Deferred (data-backed, not in this PR)

- **Card 2 (`getTopAncestorsByDescendantCount`, O(N·D) PHP walk)** — the issue's suggested reverse-topological set-memoisation was prototyped against the live graph (verified acyclic, so it is *correct*). Measured: 2.5× faster (184 ms → 74 ms on the 4.7k tree) **but 109 MB resident** — which extrapolates to multi-GB / OOM on the 105k benchmark tree the concern targets. The current per-node BFS is memory-frugal (0.3 MB) and 184 ms on the largest *real* tree. Shipping the rewrite would trade an acceptable time cost for a worse memory regression at scale, so it is held.
- **Card 4 (`getTreeRecords`, 29 → ~16 queries)** — constant cost (does not grow with tree size); the bulk-resolve restructure spans ~15 record sub-methods across 4 repositories for no scaling benefit. Disproportionate; deferred.

## Tests & verification
- TDD per card: a depth-independence query-count assertion (the deep chain must not cost more queries than a shallow one) for Card 1; a shared-fold query-count assertion + a count↔Top-N cardinality invariant (both sexes + all) for Card 3.
- Strengthening the threshold test to exact values also corrected a stale fixture docblock (the all-sexes distinct count is six, not five — the sex-`U` individual counts).
- `composer ci:test` green (669 PHPUnit + 27 JS); before/after re-profiled live.

Addresses #154 (Cards 1 & 3).
