### PR TITLE
GH-161: Fix GenerationDepth under-counting under asymmetric pedigree collapse

### DIFF
--- a/src/Model/Tree/GenerationDepthReport.php
+++ b/src/Model/Tree/GenerationDepthReport.php
@@ -37,7 +37,7 @@ final readonly class GenerationDepthReport implements JsonSerializable
     /**
      * @param int                    $maxDepth        Deepest verified parent-child chain length across the tree
      * @param array<int, int>        $distribution    Histogram `depthBucket → count of individuals`
-     * @param bool                   $capped          Whether the walk hit the safety cap (typical sign of cyclic FAMC/FAMS edits)
+     * @param bool                   $capped          Whether the walk hit the safety cap — a genuine ≥MAX_DEPTH acyclic descent; a cyclic edit is absorbed and does NOT trip it
      * @param list<list<Individual>> $chains          Sample of verified chains anchored at the maximum depth
      * @param int                    $totalChainCount Total number of chains found at the maximum depth (≥ `count($chains)`)
      */

--- a/src/Support/Calc/GenerationDepth.php
+++ b/src/Support/Calc/GenerationDepth.php
@@ -316,20 +316,22 @@ final readonly class GenerationDepth
             return;
         }
 
-        // Stack frames are [node, leaving]: a node is first popped to be
-        // ENTERED (children scheduled), then popped again to LEAVE (its depth
-        // computed from the now-resolved children).
-        /** @var list<array{0: string, 1: bool}> $stack */
-        $stack  = [[$id, false]];
+        // Stack frames are [node, leaving, children]: a node is first popped to
+        // be ENTERED (its neighbour list resolved once and its children
+        // scheduled), then popped again to LEAVE (its depth computed from the
+        // now-resolved children). The neighbour list is carried in the LEAVE
+        // frame so the closure is resolved exactly once per node, not twice.
+        /** @var list<array{0: string, 1: bool, 2: list<string>|null}> $stack */
+        $stack  = [[$id, false, null]];
         $onPath = [];
 
         while ($stack !== []) {
-            [$node, $leaving] = array_pop($stack);
+            [$node, $leaving, $children] = array_pop($stack);
 
             if ($leaving) {
                 $deepest = 0;
 
-                foreach ($neighbours($node) as $child) {
+                foreach ($children ?? [] as $child) {
                     if (isset($cache[$child])) {
                         $deepest = max($deepest, $cache[$child] + 1);
                     }
@@ -353,9 +355,10 @@ final readonly class GenerationDepth
             }
 
             $onPath[$node] = true;
-            $stack[]       = [$node, true];
+            $children      = $neighbours($node);
+            $stack[]       = [$node, true, $children];
 
-            foreach ($neighbours($node) as $child) {
+            foreach ($children as $child) {
                 // Skip resolved children and back-edges to the current path
                 // (the cycle guard); both are read back during the LEAVE pass.
                 if (isset($cache[$child])) {
@@ -366,7 +369,7 @@ final readonly class GenerationDepth
                     continue;
                 }
 
-                $stack[] = [$child, false];
+                $stack[] = [$child, false, null];
             }
         }
     }

--- a/src/Support/Calc/GenerationDepth.php
+++ b/src/Support/Calc/GenerationDepth.php
@@ -17,6 +17,7 @@ use function array_map;
 use function array_pop;
 use function array_reverse;
 use function max;
+use function min;
 use function sort;
 
 /**
@@ -26,11 +27,13 @@ use function sort;
  * descendants are direct children has depth 1, and so on. The tree-wide maximum
  * is the longest recorded vertical descent.
  *
- * The walk is bounded by `MAX_DEPTH` so an accidentally-cyclic GEDCOM (rare but
- * possible — self-referential FAMC + FAMS edits) cannot loop forever. Within a
- * single individual's DFS, a visited-set protects against the more mundane case
- * of pedigree-collapse where the same descendant could be re-walked through
- * different lines.
+ * Depth is computed as a longest-path memoisation over the parentage graph
+ * (`depth(node) = 1 + max(depth(child))`), so pedigree collapse — where the same
+ * descendant is reachable through several lines of possibly different length —
+ * always yields the LONGEST descent, independent of traversal order. The walk is
+ * bounded by `MAX_DEPTH` and a per-walk on-path set so an accidentally-cyclic
+ * GEDCOM (rare but possible — self-referential FAMC + FAMS edits) cannot loop
+ * forever.
  *
  * @author  Rico Sonntag <mail@ricosonntag.de>
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
@@ -285,13 +288,26 @@ final readonly class GenerationDepth
 
     /**
      * Iterative-DFS skeleton shared by {@see deepestDescendantDistance()} and
-     * {@see deepestAncestorDistance()}: memoise the largest generation distance
-     * from `$id` to any reachable leaf, following whichever half of the
-     * parentage graph `$neighbours` exposes. An explicit stack keeps deep
-     * chains off PHP's recursion budget, and the per-walk `visited` set kills
-     * any cycle the moment it would loop back on itself.
+     * {@see deepestAncestorDistance()}: memoise the LONGEST generation distance
+     * from every reachable node to a leaf — `depth(node) = 1 + max(depth(child))`,
+     * `0` for a leaf — following whichever half of the parentage graph
+     * `$neighbours` exposes. The walk is a post-order pass over an explicit
+     * stack (so deep chains stay off PHP's recursion budget), and the per-walk
+     * on-path set breaks cycles: a back-edge to a node still being resolved on
+     * the current path contributes nothing, so an accidentally-cyclic FAMC/FAMS
+     * edit cannot loop — it is absorbed to a small finite depth and does NOT
+     * reach the cap. Each depth is clamped to `MAX_DEPTH`, so only a genuine
+     * ≥100-generation ACYCLIC descent saturates there and trips the `capped`
+     * data-quality signal; corrupt cyclic parentage degrades silently.
      *
-     * @param array<array-key, int>          $cache      In/out cache, mutated on every call
+     * A plain visited-set DFS is WRONG here: it marks a node at the first
+     * (possibly shorter) depth it is reached and skips the deeper re-visit, so a
+     * node reachable via two paths of UNEQUAL length (asymmetric pedigree
+     * collapse) is under-counted whenever the shorter path is explored first —
+     * an iteration-order-dependent defect. The post-order memoisation records
+     * each node's depth exactly once and order-independently (GH-161).
+     *
+     * @param array<array-key, int>          $cache      In/out cache, mutated on every call; every reachable node is memoised
      * @param callable(string): list<string> $neighbours Next ids to walk from a given node; an empty list ends the branch
      */
     private static function walkDeepestDistance(string $id, array &$cache, callable $neighbours): void
@@ -300,31 +316,59 @@ final readonly class GenerationDepth
             return;
         }
 
-        /** @var list<array{0: string, 1: int}> $stack */
-        $stack   = [[$id, 0]];
-        $visited = [];
-        $deepest = 0;
+        // Stack frames are [node, leaving]: a node is first popped to be
+        // ENTERED (children scheduled), then popped again to LEAVE (its depth
+        // computed from the now-resolved children).
+        /** @var list<array{0: string, 1: bool}> $stack */
+        $stack  = [[$id, false]];
+        $onPath = [];
 
         while ($stack !== []) {
-            [$current, $depth] = array_pop($stack);
+            [$node, $leaving] = array_pop($stack);
 
-            if (isset($visited[$current])) {
+            if ($leaving) {
+                $deepest = 0;
+
+                foreach ($neighbours($node) as $child) {
+                    if (isset($cache[$child])) {
+                        $deepest = max($deepest, $cache[$child] + 1);
+                    }
+                }
+
+                $cache[$node] = min($deepest, self::MAX_DEPTH);
+                unset($onPath[$node]);
+
                 continue;
             }
 
-            if ($depth > self::MAX_DEPTH) {
+            // A node already memoised (reached through another branch) or
+            // already on the current path (a second parent scheduled it before
+            // it was entered) needs no second ENTER.
+            if (isset($cache[$node])) {
                 continue;
             }
 
-            $visited[$current] = true;
-            $deepest           = max($deepest, $depth);
+            if (isset($onPath[$node])) {
+                continue;
+            }
 
-            foreach ($neighbours($current) as $next) {
-                $stack[] = [$next, $depth + 1];
+            $onPath[$node] = true;
+            $stack[]       = [$node, true];
+
+            foreach ($neighbours($node) as $child) {
+                // Skip resolved children and back-edges to the current path
+                // (the cycle guard); both are read back during the LEAVE pass.
+                if (isset($cache[$child])) {
+                    continue;
+                }
+
+                if (isset($onPath[$child])) {
+                    continue;
+                }
+
+                $stack[] = [$child, false];
             }
         }
-
-        $cache[$id] = $deepest;
     }
 
     /**

--- a/tests/Unit/GenerationDepthTest.php
+++ b/tests/Unit/GenerationDepthTest.php
@@ -109,8 +109,8 @@ final class GenerationDepthTest extends TestCase
      * When two distinct child lines converge into the same deeper ancestor
      * (pedigree collapse via cousin marriage), the ancestor's depth is computed
      * from the LONGEST downward path — not the sum of both. Verifies the
-     * visited-set within a single DFS prevents a re-entry from doubling the
-     * depth.
+     * longest-path memoisation (`depth = 1 + max(child)`) takes the deeper
+     * branch rather than adding the two converging lines.
      */
     #[Test]
     public function pedigreeCollapseChoosesLongestDownwardPath(): void
@@ -137,10 +137,61 @@ final class GenerationDepthTest extends TestCase
     }
 
     /**
+     * Pedigree collapse where the two reconverging lines have DIFFERENT
+     * lengths: the deeper individual's depth must be the LONGER path, and the
+     * answer must not depend on which path the walk happens to explore first.
+     * {@see pedigreeCollapseChoosesLongestDownwardPath} only uses equal-length
+     * lines, so it never actually exercises "longest wins over a shorter
+     * alternative" (regression for #161).
+     */
+    #[Test]
+    public function downwardWalkTakesTheLongerOfTwoUnequalLengthPaths(): void
+    {
+        // C1 is reachable downward from G via two paths of different length:
+        //   G -> P1 -> C1         (2)
+        //   G -> Q  -> P2 -> C1   (3)
+        // The entry order below makes the SHORTER path explored first, which
+        // a visited-set DFS under-counts to maxDepth 2.
+        $parentOf = [
+            'C1' => ['P1', 'P2'],
+            'Q'  => ['G', null],
+            'P2' => ['Q', null],
+            'P1' => ['G', null],
+        ];
+
+        $result = GenerationDepth::compute($parentOf);
+
+        self::assertSame(3, $result['maxDepth']);
+        self::assertSame(['G', 'Q', 'P2', 'C1'], $result['deepestChain']);
+    }
+
+    /**
+     * A legitimate but implausibly long ACYCLIC descent (deeper than MAX_DEPTH)
+     * saturates at the cap and trips the `capped` data-quality flag. Pins the
+     * per-node `min($depth, MAX_DEPTH)` clamp the longest-path rewrite introduced
+     * (regression for #161).
+     */
+    #[Test]
+    public function chainDeeperThanMaxDepthClampsAndTripsCappedFlag(): void
+    {
+        // A linear chain of 150 generations: I0 (child) up to I150 (eldest).
+        $parentOf = [];
+
+        for ($i = 0; $i < 150; ++$i) {
+            $parentOf['I' . $i] = ['I' . ($i + 1), null];
+        }
+
+        $result = GenerationDepth::compute($parentOf);
+
+        self::assertSame(GenerationDepth::MAX_DEPTH, $result['maxDepth'], 'Depth saturates at MAX_DEPTH');
+        self::assertTrue($result['capped'], 'A >MAX_DEPTH acyclic chain trips the capped signal');
+    }
+
+    /**
      * A cycle (illegal but possible: someone self-edits the parent map so an
-     * ancestor points back to a descendant) must not loop forever. The
-     * visited-set on a per-walk basis breaks the cycle; depth is bounded but
-     * the `capped` flag may or may not trip depending on chain length.
+     * ancestor points back to a descendant) must not loop forever. The per-walk
+     * on-path back-edge guard absorbs the cycle to a small finite depth, so it
+     * never trips `capped` (which signals only genuinely long acyclic descent).
      */
     #[Test]
     public function cyclicParentMapDoesNotLoopForever(): void
@@ -159,6 +210,10 @@ final class GenerationDepthTest extends TestCase
         self::assertGreaterThanOrEqual(0, $result['maxDepth']);
         self::assertLessThanOrEqual(GenerationDepth::MAX_DEPTH, $result['maxDepth']);
         self::assertNotSame([], $result['distribution']);
+        // A cycle is absorbed by the on-path back-edge guard to a small finite
+        // depth — it must NOT saturate the cap, so `capped` stays false (the
+        // flag signals only genuinely long acyclic descent, not corrupt data).
+        self::assertFalse($result['capped']);
     }
 
     /**
@@ -298,6 +353,31 @@ final class GenerationDepthTest extends TestCase
 
         self::assertSame(3, $upDistance['C'] ?? null, 'Both parents must be walked and the deeper line wins');
         self::assertSame(2, $upDistance['X'] ?? null, 'A null father must not stop the maternal line');
+    }
+
+    /**
+     * Ancestor-side counterpart of {@see downwardWalkTakesTheLongerOfTwoUnequalLengthPaths}:
+     * a node reachable UPWARD via two lines of unequal length, arranged so the
+     * SHORTER line is explored first, must still record the longer distance —
+     * the upward walk shares the same longest-path memoisation (regression for
+     * #161).
+     */
+    #[Test]
+    public function upwardWalkTakesTheLongerOfTwoUnequalLengthPaths(): void
+    {
+        // L reaches the eldest ancestor A via two upward lines:
+        //   L -> F -> N -> A   (3, paternal — explored second)
+        //   L -> M -> A        (2, maternal — explored first)
+        $parentOf = [
+            'L' => ['F', 'M'],
+            'F' => ['N', null],
+            'N' => ['A', null],
+            'M' => ['A', null],
+        ];
+
+        $upDistance = GenerationDepth::upDistanceCache($parentOf);
+
+        self::assertSame(3, $upDistance['L'] ?? null);
     }
 
     /**

--- a/tests/Unit/GenerationDepthTest.php
+++ b/tests/Unit/GenerationDepthTest.php
@@ -185,6 +185,13 @@ final class GenerationDepthTest extends TestCase
 
         self::assertSame(GenerationDepth::MAX_DEPTH, $result['maxDepth'], 'Depth saturates at MAX_DEPTH');
         self::assertTrue($result['capped'], 'A >MAX_DEPTH acyclic chain trips the capped signal');
+        // Chain reconstruction still works under clamping: the chosen root is
+        // the boundary node (the shallowest one at MAX_DEPTH, I100), whose
+        // descent decrements cleanly to the leaf — so the chain rebuilds to
+        // MAX_DEPTH + 1 nodes rather than truncating at the clamp.
+        self::assertCount(GenerationDepth::MAX_DEPTH + 1, $result['deepestChain']);
+        self::assertSame('I100', $result['deepestChain'][0]);
+        self::assertSame('I0', $result['deepestChain'][GenerationDepth::MAX_DEPTH]);
     }
 
     /**


### PR DESCRIPTION
Closes #161.

## The bug

`GenerationDepth`'s depth walk used a per-walk `visited` set that marked a node the first time it was popped. When a node is reachable via two paths of **unequal length** (asymmetric pedigree collapse — half-cousin / uncle-niece unions) and the **shorter** path is explored first, the node is marked at the shallower depth and its deeper re-visit is skipped, so the longer path is never counted. The recorded depth is too small, and the result is **iteration-order dependent**.

Reproducer (verified): `compute(['C1'=>['P1','P2'],'Q'=>['G',null],'P2'=>['Q',null],'P1'=>['G',null]])` returned maxDepth 2 instead of 3.

## The fix

Replace the visited-set DFS with an **iterative post-order longest-path memoisation**: `depth(node) = min(1 + max(depth(child)), MAX_DEPTH)`, 0 for a leaf. It is correct independent of traversal order.

- **Cycles** are broken by a per-walk `$onPath` set — a back-edge to a node still on the path contributes nothing, so a cyclic FAMC/FAMS edit is absorbed to a small finite depth. It does **not** trip `capped`, which now signals only a genuine ≥MAX_DEPTH **acyclic** descent (docblocks + a public report-model `@param` corrected accordingly).
- The shared helper drives **both** the descendant (`depthCache`) and ancestor (`upDistanceCache`) walks, so both directions are fixed.
- The memoisation writes every reachable node once, turning the per-id re-walk from **O(V·E)** into a single **O(V+E)** sweep (a perf win on large trees, confirmed by the performance review).

## Tests

- Descendant + ancestor reproducers (two unequal-length paths, shorter explored first) — both RED on the pre-fix code, verified.
- A >MAX_DEPTH (150-generation) chain pinning the `min()` clamp + `capped === true`.
- A cyclic-input `capped === false` assertion pinning the absorb-not-cap semantics.

## Verification

- `composer ci:test` green (PHPStan max, Rector, CGL, 0 clones, **693 tests**).
- Two audit rounds across correctness / performance / test-quality / data-semantics / PHP-style lenses; round 1's correctness was fuzz-verified against a canonical longest-path (tens of thousands of random DAGs, zero mismatches), round 2's findings (cap-branch coverage, cycle/capped doc accuracy) all addressed.

## Follow-up

Closes #162 — the neighbour-closure-once-per-node optimisation is implemented in this PR (commit GH-162), pulled in from the Gemini review.