### PR TITLE
Align gauge-card arcs by bottom-pinning the card body

### DIFF
--- a/resources/css/statistics.css
+++ b/resources/css/statistics.css
@@ -807,8 +807,11 @@
    neighbour; the equal-height grid row + identical card foot make the
    body bottoms — and thus the bottom-pinned arc wraps — share a baseline.
    A small bottom padding keeps the wrap off the foot so it doesn't read as
-   glued to the card edge; both gauges share it, so the baseline still aligns. */
-.wt-statistics-chart .wt-stat-card-body:has(.wt-stat-gauge-arc-wrap) {
+   glued to the card edge; both gauges share it, so the baseline still aligns.
+   Excluded when the widget is empty: chart-lib drops a `.chart-empty-state`
+   placeholder into the still-present wrap, and a "no data" message reads
+   better centred than bottom-pinned. */
+.wt-statistics-chart .wt-stat-card-body:has(.wt-stat-gauge-arc-wrap):not(:has(.chart-empty-state)) {
     justify-content: flex-end;
     padding-bottom:  15px;
 }

--- a/resources/css/statistics.css
+++ b/resources/css/statistics.css
@@ -800,6 +800,19 @@
     justify-content: flex-start;
 }
 
+/* Gauge cards pin their arc wrap to the BOTTOM of the body so two gauges
+   sharing a grid row line up on the arc even when one card's title wraps
+   to a second line. With a centred arc, the card whose taller (2-line)
+   title pushes the body down would sit its arc lower than its 1-line
+   neighbour; the equal-height grid row + identical card foot make the
+   body bottoms — and thus the bottom-pinned arc wraps — share a baseline.
+   A small bottom padding keeps the wrap off the foot so it doesn't read as
+   glued to the card edge; both gauges share it, so the baseline still aligns. */
+.wt-statistics-chart .wt-stat-card-body:has(.wt-stat-gauge-arc-wrap) {
+    justify-content: flex-end;
+    padding-bottom:  15px;
+}
+
 /* chart-lib's `renderEmptyState()` appends a bare
    `<div class="chart-empty-state">…</div>` whenever a widget receives
    an empty / all-zero dataset. Style it to match the PHTML-level


### PR DESCRIPTION
## Problem

On the statistics dashboard, two gauge cards sharing a grid row drift out of vertical alignment when one card's title wraps to a **second line**: the taller `.wt-stat-card-head` pushes the centred arc down, so the two `.wt-stat-gauge-arc-container` no longer sit on one line.

## Fix

Bottom-pin the gauge card body (`justify-content: flex-end` on `.wt-stat-card-body:has(.wt-stat-gauge-arc-wrap)`) so the arc wraps share the body-bottom baseline regardless of head height. The equal-height grid row + identical card foot keep both arcs level. A `15px` bottom padding lifts the wrap off the foot so it doesn't read as glued to the card edge — both gauges share it, so the baseline still aligns.

Scoped via `:has(.wt-stat-gauge-arc-wrap)` so only gauge cards are affected (list / scalar / records cards keep their existing body alignment).

## Verification

Browser-verified against a live tree at a 2-column viewport: with a forced 2-line title on one card, the two arc containers' `top` are identical (gap 0 px) and the wrap sits ~20 px above the foot. Pure CSS; no PHP/JS touched.