### PR TITLE
Rank sexRatioAnomalies raw + resolve only the Top-N (fixes the N+1, realigns with the raw-rank convention)

### DIFF
--- a/src/Repository/FamilyRepository.php
+++ b/src/Repository/FamilyRepository.php
@@ -32,6 +32,7 @@ use MagicSunday\Webtrees\Statistic\Support\Gedcom\GedcomScanner;
 use MagicSunday\Webtrees\Statistic\Support\Gedcom\RecordName;
 use MagicSunday\Webtrees\Statistic\Support\Gedcom\RowCast;
 
+use function array_column;
 use function array_key_exists;
 use function array_slice;
 use function array_unique;
@@ -209,7 +210,10 @@ final readonly class FamilyRepository
             }
         }
 
-        $anomalies = [];
+        // Qualify candidates from the raw counts — no record resolution is
+        // needed for the gate or the ranking comparator.
+        /** @var list<array{xref: string, sons: int, daughters: int, total: int}> $candidates */
+        $candidates = [];
 
         foreach ($byFamily as $familyId => $counts) {
             $sons      = $counts['sons'];
@@ -226,46 +230,63 @@ final readonly class FamilyRepository
                 continue;
             }
 
-            $family = Registry::familyFactory()->make($familyId, $this->tree);
-
-            if (!$family instanceof Family) {
-                continue;
-            }
-
-            // Privacy: drop the anomaly when the family is not visible to the
-            // current viewer. The label is name-privatised, but the derived
-            // sons/daughters split of a positionally-identifiable (often living)
-            // family is itself sensitive and must not surface to a viewer who
-            // cannot see the family — mirroring the RecordRowMapper gate.
-            if (!$family->canShow()) {
-                continue;
-            }
-
-            $label = RecordName::plain($family->fullName());
-
-            $anomalies[] = new SexRatioAnomaly(
-                familyXref: $familyId,
-                label: $label,
-                sons: $sons,
-                daughters: $daughters,
-            );
+            $candidates[] = ['xref' => $familyId, 'sons' => $sons, 'daughters' => $daughters, 'total' => $total];
         }
 
-        usort($anomalies, static function (SexRatioAnomaly $a, SexRatioAnomaly $b): int {
+        // Rank on the raw data, THEN cap — so only the Top-N families are ever
+        // resolved to a record (keeps the resolve loop off the N+1 path, GH-186).
+        usort($candidates, static function (array $a, array $b): int {
             // Skew descending via cross-multiplication (max_a/total_a vs
             // max_b/total_b without floating-point division), then child count
             // descending, then XREF ascending for a deterministic final order.
-            $bySkew = (max($b->sons, $b->daughters) * $a->total())
-                <=> (max($a->sons, $a->daughters) * $b->total());
+            $bySkew = (max($b['sons'], $b['daughters']) * $a['total'])
+                <=> (max($a['sons'], $a['daughters']) * $b['total']);
 
             if ($bySkew !== 0) {
                 return $bySkew;
             }
 
-            return [$b->total(), $a->familyXref] <=> [$a->total(), $b->familyXref];
+            return [$b['total'], $a['xref']] <=> [$a['total'], $b['xref']];
         });
 
-        return array_slice($anomalies, 0, $limit);
+        $top = array_slice($candidates, 0, $limit);
+
+        if ($top === []) {
+            return [];
+        }
+
+        // Batch-fetch the surviving families' gedcom in one query so each make()
+        // below is round-trip-free.
+        $gedcomQuery  = TreeScope::table($this->tree, 'families')->select(['f_id', 'f_gedcom']);
+        $gedcomByXref = [];
+
+        foreach (ChunkedWhereIn::get($gedcomQuery, 'f_id', array_column($top, 'xref')) as $row) {
+            $gedcomByXref[RowCast::string($row, 'f_id')] = RowCast::string($row, 'f_gedcom');
+        }
+
+        // Resolve only the Top-N. Privacy follows the documented raw-rank
+        // convention: the label is privatised through Family::fullName() (a
+        // family the viewer cannot see reads as "Private"), while the raw split
+        // is shown either way — matching the sibling "largest families" card.
+        $anomalies = [];
+
+        foreach ($top as $candidate) {
+            $familyId = $candidate['xref'];
+            $family   = Registry::familyFactory()->make($familyId, $this->tree, $gedcomByXref[$familyId] ?? null);
+
+            if (!$family instanceof Family) {
+                continue;
+            }
+
+            $anomalies[] = new SexRatioAnomaly(
+                familyXref: $familyId,
+                label: RecordName::plain($family->fullName()),
+                sons: $candidate['sons'],
+                daughters: $candidate['daughters'],
+            );
+        }
+
+        return $anomalies;
     }
 
     /**

--- a/src/Repository/FamilyRepository.php
+++ b/src/Repository/FamilyRepository.php
@@ -261,7 +261,15 @@ final readonly class FamilyRepository
         $gedcomByXref = [];
 
         foreach (ChunkedWhereIn::get($gedcomQuery, 'f_id', array_column($top, 'xref')) as $row) {
-            $gedcomByXref[RowCast::string($row, 'f_id')] = RowCast::string($row, 'f_gedcom');
+            $gedcom = RowCast::string($row, 'f_gedcom');
+
+            // Map only a non-empty gedcom: make() short-circuits its own fetch on
+            // any non-null argument, so an empty string would build an empty
+            // record — leave it out and let the `?? null` lookup below fall back
+            // to a real resolution.
+            if ($gedcom !== '') {
+                $gedcomByXref[RowCast::string($row, 'f_id')] = $gedcom;
+            }
         }
 
         // Resolve only the Top-N. Privacy follows the documented raw-rank

--- a/tests/Integration/FamilyRepositoryIntegrationTest.php
+++ b/tests/Integration/FamilyRepositoryIntegrationTest.php
@@ -193,31 +193,56 @@ final class FamilyRepositoryIntegrationTest extends IntegrationTestCase
     }
 
     /**
-     * The sons/daughters split of a family a viewer cannot see must not leak.
+     * Ranked extremes follow the project's raw-rank convention: a family is
+     * ranked from its raw counts and shown with a name-privatised label — not
+     * dropped — exactly like the sibling "largest families" card.
      * `sex-ratio-living.ged` has one living family (six living sons, no
-     * daughters) that clears the skew + child-count gates. The importing admin
-     * sees the anomaly; an anonymous visitor (with live people hidden) gets an
-     * empty list because the family fails `canShow()`. Drop the `canShow()` gate
-     * and the visitor would receive the family label + the 6/0 split.
+     * daughters, surname "Living") that clears the gates. To the importing admin
+     * the label is the real couple name.
+     *
+     * (The visitor side is a separate test: Family::fullName() memoises its
+     * rendered string on the cached record, so resolving once as admin would
+     * leak the real name into a later same-process visitor resolution — the two
+     * privacy universes must each start from a fresh import.)
      */
     #[Test]
-    public function getSexRatioAnomaliesDropsAFamilyAVisitorCannotSee(): void
+    public function getSexRatioAnomaliesShowsTheRealLabelToTheAdmin(): void
+    {
+        $tree = $this->importFixtureTree('sex-ratio-living.ged');
+
+        $result = (new FamilyRepository($tree))->getSexRatioAnomalies();
+
+        self::assertCount(1, $result, 'the living skewed family is an anomaly');
+        self::assertSame('F1', $result[0]->familyXref);
+        self::assertSame(6, $result[0]->sons);
+        self::assertSame(0, $result[0]->daughters);
+        self::assertStringContainsString('Living', $result[0]->label, 'admin sees the real surname');
+    }
+
+    /**
+     * Same fixture, anonymous visitor with live people hidden: the family is
+     * still ranked and shown with its raw 6/0 split, but the label is privatised
+     * (the real surname absent) — NOT dropped. Resolved fresh as the visitor so
+     * no admin-computed `fullName()` is cached. Resolving only the Top-N keeps
+     * this off the N+1 path (GH-186).
+     */
+    #[Test]
+    public function getSexRatioAnomaliesShowsAHiddenFamilyWithAPrivatisedLabel(): void
     {
         $tree = $this->importFixtureTree('sex-ratio-living.ged');
         $tree->setPreference('HIDE_LIVE_PEOPLE', '1');
         $tree->setPreference('SHOW_DEAD_PEOPLE', (string) Auth::PRIV_PRIVATE);
 
-        $asAdmin = (new FamilyRepository($tree))->getSexRatioAnomalies();
-        self::assertCount(1, $asAdmin, 'precondition: the living skewed family is an anomaly for the admin');
-        self::assertSame('F1', $asAdmin[0]->familyXref);
-
         Auth::logout();
 
-        self::assertSame(
-            [],
-            (new FamilyRepository($tree))->getSexRatioAnomalies(),
-            'a living family the visitor cannot see must not surface its son/daughter split',
-        );
+        $result = (new FamilyRepository($tree))->getSexRatioAnomalies();
+
+        self::assertCount(1, $result, 'the family is ranked + shown, not dropped');
+        self::assertSame('F1', $result[0]->familyXref);
+        self::assertSame(6, $result[0]->sons, 'raw split preserved');
+        self::assertSame(0, $result[0]->daughters);
+        self::assertNotSame('', $result[0]->label, 'a privatised placeholder label is still rendered');
+        self::assertStringNotContainsString('Living', $result[0]->label, 'the real surname is privatised for the visitor');
     }
 
     /**


### PR DESCRIPTION
Fixes #186 — the one finding from the fourth verification sweep (performance + edge lenses).

### Problem
`FamilyRepository::getSexRatioAnomalies()` resolved `Registry::make()` (one `SELECT f_gedcom` per row) + `canShow()` for **every** family clearing the skew/child-count gate, because `array_slice(…, $limit)` was applied only after the loop and `usort`. The N+1 was paid over the whole qualifying population (hundreds-to-thousands on the 105k benchmark tree), not the Top-N. It also contradicted the method's own docblock and diverged from the sibling ranked-list cards (which rank raw + privatise the label, never drop) — an inconsistency introduced by the GH-182 `canShow()` drop.

### Fix
Rank on the raw `$byFamily` data (the comparator reads only sons/daughters/total/xref), cap to `$limit`, then resolve `make()` for only the survivors — batch-fetching their `f_gedcom` in one `ChunkedWhereIn` query (mirroring `FamilyRankingRepository`). Privacy follows the documented raw-rank convention: label privatised via `Family::fullName()`, raw split shown, family not dropped — consistent with "largest families: Private, 15 children".

Net: O(qualifying) queries -> 1 batch query + <=`$limit` resolves.

### Tests
The privacy test splits into an admin case (real couple label) and a visitor case (privatised label, raw split preserved, NOT dropped). `fullName()` memoises its rendered string on the cached record, so each privacy universe starts from a fresh import.

Live-verified on a real tree: the Sex-ratio-anomalies card renders the ranked anomalies correctly (admin view); all 6 tabs render, 0 console errors. `composer ci:test` green (718 tests); the integration suite runs on the MySQL `ONLY_FULL_GROUP_BY` lane.
