### PR TITLE
Override transitive js-yaml to ^4.2.0 (Dependabot DoS alert)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2454,14 +2454,11 @@
             }
         },
         "node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
+            "license": "Python-2.0"
         },
         "node_modules/array-find-index": {
             "version": "1.0.2",
@@ -3511,20 +3508,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/estree-walker": {
@@ -4715,14 +4698,23 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "^2.0.1"
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
@@ -5675,13 +5667,6 @@
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-ranges": "^2.0.0"
             }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true,
-            "license": "BSD-3-Clause"
         },
         "node_modules/stack-utils": {
             "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
         ],
         "transform": {}
     },
+    "overrides": {
+        "js-yaml": "^4.2.0"
+    },
     "devDependencies": {
         "@biomejs/biome": "2.4.16",
         "@rollup/plugin-node-resolve": "^16.0",


### PR DESCRIPTION
Closes the open Dependabot alert for `js-yaml`.

The only `js-yaml` in the dependency tree is **3.14.2** — a transitive **devDependency** pulled by `@istanbuljs/load-nyc-config` (coverage-config loader). The advisory (merge-key quadratic-complexity DoS) is patched only in **4.2.0**, a major bump from the 3.x line. Pin it via a top-level `overrides` entry.

- Build-time dev dependency only — **not bundled** into the shipped `webtrees-statistics.zip`, and it parses only the project's own trusted config, so the DoS is not reachable by a webtrees admin. This pin closes the alert rather than fixing an exploitable path.
- The full JS toolchain stays green on 4.2.0: biome lint + format, `tsc --noEmit`, jscpd (0 clones), jest (20/20). The 3.x-API consumer (`safeLoad`) is not exercised by the test run.
