### PR TITLE
GH-213: Resolve multi-FAMC parents deterministically

### DIFF
--- a/src/Repository/ParentMapRepository.php
+++ b/src/Repository/ParentMapRepository.php
@@ -58,8 +58,16 @@ final class ParentMapRepository
      * Build a child-id → [father-id|null, mother-id|null] map for the
      * configured tree. Children with no resolvable FAM-spouse pair are absent
      * from the map; callers treat absence as "root of the walk — no further
-     * ancestors known". Result is cached for the lifetime of the repository
-     * instance.
+     * ancestors known". A child with several FAMC families (a birth family plus
+     * an adoptive/foster one) resolves to a single, DETERMINISTIC pair: the
+     * family carrying the most parent information, ties broken on the
+     * lexicographically lowest family xref (the xref column is text, so the
+     * ordering is byte/sort order, not numeric) — never the arbitrary,
+     * engine-dependent last row. Malformed parent slots are dropped before
+     * scoring: a person is never their own parent, and a parent duplicated
+     * across both spouse slots counts once, so a corrupt family cannot
+     * out-score a valid one. Result is cached for the lifetime of the
+     * repository instance.
      *
      * The key type is `array-key`, not `string`: a digit-only XREF ("54") is
      * silently coerced to an int the moment it indexes the array, so callers
@@ -93,12 +101,29 @@ final class ParentMapRepository
             $familyParents[$famId] = [$husb, $wife];
         }
 
+        // ORDER BY l_to pins the per-child family scan to ascending family-xref
+        // order so the tie-break below ("lexicographically lowest family xref
+        // wins") is stable regardless of the engine's default row order. l_to is
+        // a text column, so the ordering is byte/sort order (F10 sorts before
+        // F2), not numeric. l_from is ordered too so the whole scan is
+        // deterministic.
         $childRows = TreeScope::table($this->tree, 'link')
             ->where('l_type', '=', 'FAMC')
+            ->orderBy('l_from')
+            ->orderBy('l_to')
             ->select(['l_from AS child', 'l_to AS family'])
             ->get();
 
-        $parentOf = [];
+        // A child may carry several FAMC links (a birth family plus an
+        // adoptive/foster one). The previous unordered last-write-wins picked an
+        // arbitrary, engine-dependent family. Instead keep the family carrying
+        // the most parent information (both parents > one > none); equal-score
+        // ties resolve to the lexicographically lowest family xref, which the
+        // ascending scan makes the first seen. The link table carries no
+        // `2 PEDI`, so birth vs. adoptive is not distinguished — the choice is
+        // deterministic, not pedigree-aware.
+        $parentOf    = [];
+        $parentScore = [];
 
         foreach ($childRows as $row) {
             $child  = RowCast::string($row, 'child');
@@ -116,7 +141,24 @@ final class ParentMapRepository
                 continue;
             }
 
-            $parentOf[$child] = $familyParents[$family];
+            $pair = $familyParents[$family];
+
+            // Drop malformed parent slots before scoring so a corrupt family
+            // cannot out-score a valid one. A person is never their own parent
+            // (the child listed as its own family's spouse — reachable via an
+            // imported GEDCOM and via the core "Change family members" editor,
+            // which enforces no parent ≠ child rule), and a parent duplicated
+            // across both spouse slots carries one parent's worth of
+            // information, not two.
+            $father = ($pair[0] !== $child) ? $pair[0] : null;
+            $mother = (($pair[1] !== $child) && ($pair[1] !== $father)) ? $pair[1] : null;
+
+            $score = ($father !== null ? 1 : 0) + ($mother !== null ? 1 : 0);
+
+            if (!isset($parentScore[$child]) || ($score > $parentScore[$child])) {
+                $parentOf[$child]    = [$father, $mother];
+                $parentScore[$child] = $score;
+            }
         }
 
         $this->cache = $parentOf;

--- a/src/Repository/ParentMapRepository.php
+++ b/src/Repository/ParentMapRepository.php
@@ -147,11 +147,15 @@ final class ParentMapRepository
             // cannot out-score a valid one. A person is never their own parent
             // (the child listed as its own family's spouse — reachable via an
             // imported GEDCOM and via the core "Change family members" editor,
-            // which enforces no parent ≠ child rule), and a parent duplicated
-            // across both spouse slots carries one parent's worth of
-            // information, not two.
+            // which enforces no parent ≠ child rule).
             $father = ($pair[0] !== $child) ? $pair[0] : null;
-            $mother = (($pair[1] !== $child) && ($pair[1] !== $father)) ? $pair[1] : null;
+            $mother = ($pair[1] !== $child) ? $pair[1] : null;
+
+            // A parent duplicated across both spouse slots carries one parent's
+            // worth of information, not two — keep it in the father slot only.
+            if ($father === $mother) {
+                $mother = null;
+            }
 
             $score = ($father !== null ? 1 : 0) + ($mother !== null ? 1 : 0);
 

--- a/tests/Integration/ParentMapRepositoryIntegrationTest.php
+++ b/tests/Integration/ParentMapRepositoryIntegrationTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Test\Integration;
+
+use MagicSunday\Webtrees\Statistic\Repository\ParentMapRepository;
+use MagicSunday\Webtrees\Statistic\Support\Database\TreeScope;
+use MagicSunday\Webtrees\Statistic\Support\Gedcom\RowCast;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+
+/**
+ * End-to-end test of {@see ParentMapRepository} against `parent-map-multi-famc.ged`,
+ * focused on the deterministic resolution of a child carrying MORE THAN ONE
+ * `FAMC` link (a birth family plus an adoptive/secondary family):
+ *
+ *   I1 (Child A) → F2 [father I11, mother I12] and F1 [father I10 only]
+ *   I2 (Child B) → F4 [both], F3 [both] and F5 [both] — a three-way tie
+ *   I3 (Child C) → F6 [father I20 only] and F7 [no parents]
+ *
+ * The previous implementation assigned the parent pair unconditionally per
+ * `FAMC` row with no ordering, so the LAST family in the database's return order
+ * won — an arbitrary, engine-dependent choice. The repository now keeps the
+ * family carrying the most parent information (both > one > none) and breaks
+ * ties on the lexicographically lowest family xref (via the ascending
+ * `ORDER BY l_to` scan), so the result is stable regardless of storage or
+ * return order.
+ *
+ * The fixture deliberately lists each child's `FAMC` links so that BOTH failure
+ * modes are caught — the retired last-write-wins bug (which picked the last row)
+ * and a removal of the deterministic `ORDER BY` (which would fall back to the
+ * first-seen row):
+ *
+ *   - I1 names the info-winner F2 BEFORE the father-only F1, so last-write would
+ *     wrongly pick F1 → guards the parent-information scoring.
+ *   - I2 lists its three equal-score families as F4, F3, F5, placing the winner
+ *     F3 (lowest xref) in the MIDDLE: last-write would pick the last row F5 and
+ *     a dropped `ORDER BY` would pick the first row F4 — only the ascending scan
+ *     yields F3 → guards the tie-break AND its determinism at once.
+ *   - I3 names the one-parent F6 BEFORE the no-parent F7, so last-write would
+ *     wrongly pick F7 → guards the "any parent beats none" scoring level.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+#[CoversClass(ParentMapRepository::class)]
+#[UsesClass(TreeScope::class)]
+#[UsesClass(RowCast::class)]
+final class ParentMapRepositoryIntegrationTest extends AbstractIntegrationTestCase
+{
+    /**
+     * A child with two `FAMC` families resolves to the one carrying the most
+     * parent information — even when that family has the HIGHER xref, so the
+     * choice cannot be explained by xref order alone. Child A's F1 records only
+     * a father, while F2 records both parents; F2 wins. The fixture lists F2
+     * before F1, so the retired last-write-wins code would pick the father-only
+     * F1 — this assertion therefore fails without the parent-information scoring.
+     */
+    #[Test]
+    public function buildPrefersTheFamilyWithMoreParentInformation(): void
+    {
+        $tree     = $this->importFixtureTree('parent-map-multi-famc.ged');
+        $parentOf = (new ParentMapRepository($tree))->build();
+
+        self::assertArrayHasKey('I1', $parentOf);
+        self::assertSame(['I11', 'I12'], $parentOf['I1']);
+    }
+
+    /**
+     * When several `FAMC` families carry equal parent information the
+     * lexicographically lowest family xref wins deterministically. Child B's F3,
+     * F4 and F5 all record both parents, so F3 (the lowest xref) is chosen on
+     * every run, independent of the database's return order. The fixture lists
+     * them F4, F3, F5 — placing the winner F3 in the MIDDLE — so neither the
+     * retired last-write-wins code (which would pick the last row F5) nor a
+     * dropped `ORDER BY` (which would pick the first row F4) can produce F3; only
+     * the ascending `ORDER BY l_to` scan does.
+     */
+    #[Test]
+    public function buildBreaksEqualInformationTiesOnTheLowestFamilyXref(): void
+    {
+        $tree     = $this->importFixtureTree('parent-map-multi-famc.ged');
+        $parentOf = (new ParentMapRepository($tree))->build();
+
+        self::assertArrayHasKey('I2', $parentOf);
+        self::assertSame(['I13', 'I14'], $parentOf['I2']);
+    }
+
+    /**
+     * A family recording a single parent outranks one recording no parents at
+     * all — the middle level of the "both > one > none" scoring rule. Child C's
+     * F6 names one father while F7 names no parents; F6 wins. The fixture lists
+     * F6 before the no-parent F7, so the retired last-write-wins code would pick
+     * the empty F7 — this assertion therefore fails without the scoring.
+     */
+    #[Test]
+    public function buildPrefersAnyParentOverAFamilyWithNoParents(): void
+    {
+        $tree     = $this->importFixtureTree('parent-map-multi-famc.ged');
+        $parentOf = (new ParentMapRepository($tree))->build();
+
+        self::assertArrayHasKey('I3', $parentOf);
+        self::assertSame(['I20', null], $parentOf['I3']);
+    }
+
+    /**
+     * A malformed family that lists the child itself as its own parent (a shape
+     * reachable both through an imported third-party GEDCOM and through the core
+     * "Change family members" editor, neither of which enforces parent ≠ child)
+     * must never out-score or displace a valid family. Child D's F8 names the
+     * child I4 as BOTH spouses (would naively score 2), while F9 names one real
+     * father I21 (score 1); the self-referential slots are dropped, so F8 scores
+     * 0 and the child resolves to the valid F9 — never to itself.
+     */
+    #[Test]
+    public function buildDropsSelfReferentialParentsSoAMalformedFamilyCannotWin(): void
+    {
+        $tree     = $this->importFixtureTree('parent-map-multi-famc.ged');
+        $parentOf = (new ParentMapRepository($tree))->build();
+
+        self::assertArrayHasKey('I4', $parentOf);
+        self::assertSame(['I21', null], $parentOf['I4']);
+    }
+
+    /**
+     * A parent duplicated across BOTH spouse slots of one family (a non-child
+     * person recorded as both HUSB and WIFE — another shape the editor and GEDCOM
+     * import permit) is one parent's worth of information, not two. Child E's
+     * only family F10 names I30 as both spouses; the duplicate is collapsed, so
+     * the child resolves to a single father `['I30', null]`, never a doubled
+     * `['I30', 'I30']`. Without the dedup the mother slot would keep the second
+     * I30 and this assertion fails.
+     */
+    #[Test]
+    public function buildDeduplicatesAParentRepeatedAcrossBothSpouseSlots(): void
+    {
+        $tree     = $this->importFixtureTree('parent-map-multi-famc.ged');
+        $parentOf = (new ParentMapRepository($tree))->build();
+
+        self::assertArrayHasKey('I5', $parentOf);
+        self::assertSame(['I30', null], $parentOf['I5']);
+    }
+
+    /**
+     * The parents that are NOT chosen for a multi-FAMC child never leak into the
+     * child's resolved pair: only the selected family's members are present, and
+     * the discarded family's parents do not appear alongside them.
+     */
+    #[Test]
+    public function buildDoesNotLeakTheDiscardedFamilyParents(): void
+    {
+        $tree     = $this->importFixtureTree('parent-map-multi-famc.ged');
+        $parentOf = (new ParentMapRepository($tree))->build();
+
+        self::assertArrayHasKey('I1', $parentOf);
+        self::assertArrayHasKey('I2', $parentOf);
+
+        // I1 resolved to F2, so the F1-only father I10 must not appear as I1's parent.
+        self::assertNotContains('I10', $parentOf['I1']);
+
+        // I2 resolved to F3, so no member of the discarded F4 or F5 is surfaced for I2.
+        self::assertNotContains('I15', $parentOf['I2']);
+        self::assertNotContains('I16', $parentOf['I2']);
+        self::assertNotContains('I18', $parentOf['I2']);
+        self::assertNotContains('I19', $parentOf['I2']);
+    }
+}

--- a/tests/fixtures/parent-map-multi-famc.ged
+++ b/tests/fixtures/parent-map-multi-famc.ged
@@ -1,0 +1,121 @@
+0 HEAD
+1 SOUR webtrees-statistics-fixture
+2 NAME parent-map-multi-famc
+1 DEST ANSTFILE
+1 CHAR UTF-8
+1 SUBM @SUBM1@
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+0 @SUBM1@ SUBM
+1 NAME Fixture
+0 @I1@ INDI
+1 NAME Child /A/
+1 SEX M
+1 FAMC @F2@
+1 FAMC @F1@
+0 @I2@ INDI
+1 NAME Child /B/
+1 SEX F
+1 FAMC @F4@
+1 FAMC @F3@
+1 FAMC @F5@
+0 @I3@ INDI
+1 NAME Child /C/
+1 SEX M
+1 FAMC @F6@
+1 FAMC @F7@
+0 @I4@ INDI
+1 NAME Child /D/
+1 SEX M
+1 FAMC @F8@
+1 FAMC @F9@
+1 FAMS @F8@
+0 @I5@ INDI
+1 NAME Child /E/
+1 SEX F
+1 FAMC @F10@
+0 @I10@ INDI
+1 NAME Solo /Father/
+1 SEX M
+1 FAMS @F1@
+0 @I11@ INDI
+1 NAME Birth /Father/
+1 SEX M
+1 FAMS @F2@
+0 @I12@ INDI
+1 NAME Birth /Mother/
+1 SEX F
+1 FAMS @F2@
+0 @I13@ INDI
+1 NAME First /Father/
+1 SEX M
+1 FAMS @F3@
+0 @I14@ INDI
+1 NAME First /Mother/
+1 SEX F
+1 FAMS @F3@
+0 @I15@ INDI
+1 NAME Second /Father/
+1 SEX M
+1 FAMS @F4@
+0 @I16@ INDI
+1 NAME Second /Mother/
+1 SEX F
+1 FAMS @F4@
+0 @I18@ INDI
+1 NAME Third /Father/
+1 SEX M
+1 FAMS @F5@
+0 @I19@ INDI
+1 NAME Third /Mother/
+1 SEX F
+1 FAMS @F5@
+0 @I20@ INDI
+1 NAME Lone /Father/
+1 SEX M
+1 FAMS @F6@
+0 @I21@ INDI
+1 NAME Valid /Father/
+1 SEX M
+1 FAMS @F9@
+0 @I30@ INDI
+1 NAME Duplicated /Parent/
+1 SEX M
+1 FAMS @F10@
+0 @F1@ FAM
+1 HUSB @I10@
+1 CHIL @I1@
+0 @F2@ FAM
+1 HUSB @I11@
+1 WIFE @I12@
+1 CHIL @I1@
+0 @F3@ FAM
+1 HUSB @I13@
+1 WIFE @I14@
+1 CHIL @I2@
+0 @F4@ FAM
+1 HUSB @I15@
+1 WIFE @I16@
+1 CHIL @I2@
+0 @F5@ FAM
+1 HUSB @I18@
+1 WIFE @I19@
+1 CHIL @I2@
+0 @F6@ FAM
+1 HUSB @I20@
+1 CHIL @I3@
+0 @F7@ FAM
+1 CHIL @I3@
+0 @F8@ FAM
+1 HUSB @I4@
+1 WIFE @I4@
+1 CHIL @I4@
+0 @F9@ FAM
+1 HUSB @I21@
+1 CHIL @I4@
+0 @F10@ FAM
+1 HUSB @I30@
+1 WIFE @I30@
+1 CHIL @I5@
+0 TRLR


### PR DESCRIPTION
## Summary

Closes #213.

A child carrying more than one `FAMC` family (a birth family plus an adoptive or
secondary one) was resolved to an arbitrary, engine-dependent family: the shared
`ParentMapRepository` scanned the `link` table unordered and let the last row
win. The chosen parents therefore varied between SQLite and MySQL and between
runs, rippling into every consumer (`KinshipRepository`,
`GenerationDepthRepository`, `EndogamyRepository` and the parent→child
`OccupationInheritanceRepository`).

## Change

Each child now resolves to a single, deterministic pair:

- **Deterministic scan** — the `FAMC` links are read under an explicit
  `ORDER BY l_from, l_to`, so the per-child family order is stable regardless of
  the engine's default row order.
- **Most-information wins** — the family carrying the most parent information
  (both parents > one > none) is kept; equal-score ties resolve to the
  lexicographically lowest family xref, which the ascending scan makes the first
  seen. The `l_to` column is text, so the ordering is byte/sort order, not
  numeric — documented inline.
- **Malformed-parent guard** — malformed slots are dropped before scoring so a
  corrupt family cannot out-score a valid one: a person is never their own
  parent (the child listed as its own family's spouse, reachable via an imported
  GEDCOM and the core "Change family members" editor), and a parent duplicated
  across both spouse slots counts once.

## Tests

A new integration test (`ParentMapRepositoryIntegrationTest`) and a dedicated
GEDCOM fixture cover the resolution end-to-end. The fixture's `FAMC` ordering is
deliberately arranged so each test is a **genuine discriminator**, verified by
temporarily reverting each production mechanism:

- the info-score winner is listed *first* → fails against the retired
  last-write-wins code;
- the three-way tie lists the winner in the *middle* of insertion order → fails
  against both last-write-wins **and** a removal of the `ORDER BY`;
- separate cases lock the one-vs-none scoring level, the self-referential-parent
  drop, and the duplicate-parent dedup (each proven red without its guard).

## Notes on cross-engine ordering

The equal-score tie-break uses `ORDER BY l_to`. Xrefs are a letter prefix plus
digits, an alphabet for which MySQL `utf8mb4_unicode_ci` and SQLite `BINARY`
produce identical relative ordering (the differentiating digit suffix sorts the
same under both), so the tie-break is engine-stable for real xrefs. The
name-collation divergence that affects `n_givn` elsewhere does not apply to the
restricted xref alphabet. The MySQL `ONLY_FULL_GROUP_BY` integration lane runs
the same fixture and is green.
