### PR TITLE
GH-216: Count every occupation in the inheritance chart

### DIFF
--- a/src/Repository/OccupationInheritanceRepository.php
+++ b/src/Repository/OccupationInheritanceRepository.php
@@ -131,12 +131,18 @@ final readonly class OccupationInheritanceRepository
             ->select(['i_id AS xref', 'i_gedcom AS gedcom'])
             ->get();
 
-        // First pass: index every individual's GEDCOM by xref so a child's
-        // parent record can be looked up without a second query.
-        $gedcomByXref = [];
+        // First pass: fold every individual's `1 OCCU` lines to their DISTINCT
+        // case-folded trades once, keyed by xref. Parsing here — rather than
+        // again for every child and every parent in the main loop — means a
+        // parent shared by several children is parsed a single time, and the
+        // resident map holds the small trade lists instead of the full GEDCOM
+        // blobs.
+        $tradesByXref = [];
 
         foreach ($rows as $row) {
-            $gedcomByXref[RowCast::string($row, 'xref')] = RowCast::string($row, 'gedcom');
+            $tradesByXref[RowCast::string($row, 'xref')] = $this->uniqueTrades(
+                GedcomScanner::extractAllTagValues(RowCast::string($row, 'gedcom'), 'OCCU'),
+            );
         }
 
         $parentOf = $this->parentMap->build();
@@ -152,15 +158,9 @@ final readonly class OccupationInheritanceRepository
             $childXref   = RowCast::string($row, 'xref');
             $childGedcom = RowCast::string($row, 'gedcom');
 
-            // Collapse the child's `1 OCCU` lines to their DISTINCT case-folded
-            // trades up front (folded key → first-seen casing): a person who
-            // repeats a trade across several lines must not iterate the
-            // cross-product below redundantly, which bounds the pairing to the
-            // handful of trades a person actually has rather than the raw line
-            // count.
-            $childTrades = $this->uniqueTrades(
-                GedcomScanner::extractAllTagValues($childGedcom, 'OCCU'),
-            );
+            // The child's distinct trades were folded in the first pass; the raw
+            // GEDCOM is still read below for the privacy-gated sample.
+            $childTrades = $tradesByXref[$childXref] ?? [];
 
             if ($childTrades === []) {
                 continue;
@@ -189,15 +189,9 @@ final readonly class OccupationInheritanceRepository
                     continue;
                 }
 
-                $parentGedcom = $gedcomByXref[$parentXref] ?? null;
-
-                if ($parentGedcom === null) {
-                    continue;
-                }
-
-                $parentTrades = $this->uniqueTrades(
-                    GedcomScanner::extractAllTagValues($parentGedcom, 'OCCU'),
-                );
+                // The parent's distinct trades were folded in the first pass, so
+                // a parent shared by several children is not re-parsed per child.
+                $parentTrades = $tradesByXref[$parentXref] ?? [];
 
                 if ($parentTrades === []) {
                     continue;

--- a/src/Repository/OccupationInheritanceRepository.php
+++ b/src/Repository/OccupationInheritanceRepository.php
@@ -34,17 +34,22 @@ use function mb_strtolower;
 /**
  * Aggregates parent → child occupation inheritance across the tree. Every child
  * who carries an occupation and whose resolvable father or mother also carries
- * one contributes a single weighted link from the parent's occupation to the
+ * one contributes one or more weighted links from a parent's occupation to the
  * child's — the data behind the Sankey diagram on the Overview tab. Both
- * parents are considered, so a child of two working parents can feed two
- * distinct flows (one per parent trade); a child whose father and mother share
- * the same trade is counted only once for that flow, never twice.
+ * parents are considered, so a child of two working parents feeds each parent's
+ * trades; a child whose father and mother share a trade is counted only once
+ * for that flow, never twice.
  *
- * Only the FIRST recorded `1 OCCU` line is read per person: a person with
- * several occupations has one primary trade, and pairing every parent trade
- * against every child trade would inflate one succession into a cross-product
- * of phantom flows. Pairs are dropped whenever either side lacks an occupation
- * — the diagram answers "given both worked, did the trade carry over?", so an
+ * EVERY recorded `1 OCCU` line is read per person and the full cross-product of
+ * (parent trade → child trade) is counted, so a person's secondary trade
+ * surfaces as both a source and a target — a father who was a Farmer AND a
+ * Carter feeds both trades to a child recorded the same way. Each distinct pair
+ * is counted once per child, so two parents sharing a trade (or the same trade
+ * repeated across a person's own `1 OCCU` lines) never doubles a band. Composite
+ * `1 OCCU` values (`Trade A und Trade B` on one line) are NOT split — the whole
+ * string is one trade; recording distinct trades on separate lines is the
+ * supported form. Pairs are dropped whenever either side lacks an occupation —
+ * the diagram answers "given both worked, did the trade carry over?", so an
  * unknown end would only add noise. Occupations are case-folded before counting
  * so spelling variants (`Smith` / `smith`) merge; the first-seen casing becomes
  * the display label.
@@ -84,9 +89,10 @@ final readonly class OccupationInheritanceRepository
      * Build the Sankey payload describing parent → child occupation flows. For
      * every individual that carries an occupation, both parents are resolved via
      * the shared parent map; for each parent that also carries an occupation the
-     * (parent-occupation → child-occupation) pair is counted once. A child is
-     * counted at most once per flow, so two parents sharing the same trade do
-     * not double the child into a single band. Only the top-N links by weight
+     * full cross-product of their (parent-occupation → child-occupation) pairs is
+     * counted, each distinct pair once per child. A child is counted at most once
+     * per flow, so two parents sharing the same trade do not double the child
+     * into a single band. Only the top-N links by weight
      * are returned so the diagram stays legible. The weighted flow map is handed
      * to {@see BipartiteSankeyAssembler}, which lays the parent and child sides
      * out as disjoint node columns (a trade that is both passed down and
@@ -146,9 +152,17 @@ final readonly class OccupationInheritanceRepository
             $childXref   = RowCast::string($row, 'xref');
             $childGedcom = RowCast::string($row, 'gedcom');
 
-            $childOccupation = GedcomScanner::extractFirstTagValue($childGedcom, 'OCCU');
+            // Collapse the child's `1 OCCU` lines to their DISTINCT case-folded
+            // trades up front (folded key → first-seen casing): a person who
+            // repeats a trade across several lines must not iterate the
+            // cross-product below redundantly, which bounds the pairing to the
+            // handful of trades a person actually has rather than the raw line
+            // count.
+            $childTrades = $this->uniqueTrades(
+                GedcomScanner::extractAllTagValues($childGedcom, 'OCCU'),
+            );
 
-            if ($childOccupation === null) {
+            if ($childTrades === []) {
                 continue;
             }
 
@@ -158,11 +172,9 @@ final readonly class OccupationInheritanceRepository
                 continue;
             }
 
-            $childKey = mb_strtolower($childOccupation);
-
-            // A child whose father and mother share the same trade must feed the
-            // band only once: track the flow keys already counted for THIS child
-            // so the second parent of an identical trade is skipped.
+            // Track the flow keys already counted for THIS child so a given
+            // (parent-trade → child-trade) pair is counted once even when both
+            // the father and the mother carry that same trade.
             $seenKeys = [];
 
             // The sample is always the child, so a child feeding several flows
@@ -183,38 +195,49 @@ final readonly class OccupationInheritanceRepository
                     continue;
                 }
 
-                $parentOccupation = GedcomScanner::extractFirstTagValue($parentGedcom, 'OCCU');
+                $parentTrades = $this->uniqueTrades(
+                    GedcomScanner::extractAllTagValues($parentGedcom, 'OCCU'),
+                );
 
-                if ($parentOccupation === null) {
+                if ($parentTrades === []) {
                     continue;
                 }
 
-                $parentKey = mb_strtolower($parentOccupation);
-                $key       = $parentKey . "\0" . $childKey;
+                // Cross-product: pair every DISTINCT parent trade against every
+                // distinct child trade so a secondary occupation surfaces as both
+                // a source and a target. Each pair is still counted once per
+                // child via $seenKeys, since the father and mother may share a
+                // trade.
+                foreach ($parentTrades as $parentKey => $parentOccupation) {
+                    foreach ($childTrades as $childKey => $childOccupation) {
+                        $key = $parentKey . "\0" . $childKey;
 
-                if (isset($seenKeys[$key])) {
-                    continue;
-                }
+                        if (isset($seenKeys[$key])) {
+                            continue;
+                        }
 
-                $seenKeys[$key] = true;
+                        $seenKeys[$key] = true;
 
-                $display[$parentKey] ??= $parentOccupation;
-                $display[$childKey]  ??= $childOccupation;
+                        $display[$parentKey] ??= $parentOccupation;
+                        $display[$childKey]  ??= $childOccupation;
 
-                $linkWeight[$key] = ($linkWeight[$key] ?? 0) + 1;
-                $linkSamples[$key] ??= [];
+                        $linkWeight[$key] = ($linkWeight[$key] ?? 0) + 1;
+                        $linkSamples[$key] ??= [];
 
-                // Resolve the sample child through the privacy layer; a null
-                // result (a record the user cannot see) is skipped and the next
-                // child fills the slot — see SankeySampleResolver::resolve().
-                if (count($linkSamples[$key]) < self::SAMPLES_PER_FLOW) {
-                    if (!$childResolved) {
-                        $childSample   = SankeySampleResolver::resolve($this->tree, $childXref, $childGedcom);
-                        $childResolved = true;
-                    }
+                        // Resolve the sample child through the privacy layer; a
+                        // null result (a record the user cannot see) is skipped
+                        // and the next child fills the slot — see
+                        // SankeySampleResolver::resolve().
+                        if (count($linkSamples[$key]) < self::SAMPLES_PER_FLOW) {
+                            if (!$childResolved) {
+                                $childSample   = SankeySampleResolver::resolve($this->tree, $childXref, $childGedcom);
+                                $childResolved = true;
+                            }
 
-                    if ($childSample instanceof SankeySample) {
-                        $linkSamples[$key][] = $childSample;
+                            if ($childSample instanceof SankeySample) {
+                                $linkSamples[$key][] = $childSample;
+                            }
+                        }
                     }
                 }
             }
@@ -223,5 +246,28 @@ final readonly class OccupationInheritanceRepository
         // Occupations were case-folded for counting, so the assembler is given
         // the key → first-seen-casing map to surface readable node labels.
         return BipartiteSankeyAssembler::assemble($linkWeight, $linkSamples, $topLinks, $display);
+    }
+
+    /**
+     * Collapse a person's raw `1 OCCU` values to their DISTINCT trades, keyed by
+     * the case-folded trade and mapped to the first-seen display casing. Reading
+     * every OCCU line means a person who records the same trade on several lines
+     * would otherwise pair it into the cross-product once per duplicate; folding
+     * to distinct trades here bounds the pairing to the trades a person actually
+     * holds and merges casing variants (`Smith` / `smith`) in one place.
+     *
+     * @param list<string> $occupations The raw `1 OCCU` values in recorded order
+     *
+     * @return array<string, string> Case-folded trade key → first-seen display casing
+     */
+    private function uniqueTrades(array $occupations): array
+    {
+        $trades = [];
+
+        foreach ($occupations as $occupation) {
+            $trades[mb_strtolower($occupation)] ??= $occupation;
+        }
+
+        return $trades;
     }
 }

--- a/tests/Integration/OccupationInheritanceRepositoryIntegrationTest.php
+++ b/tests/Integration/OccupationInheritanceRepositoryIntegrationTest.php
@@ -38,12 +38,14 @@ use function array_unique;
  * curated fixture exercises every data-layer behaviour that matters: a trade
  * passed down to four children (cap on samples), a case-folded variant that
  * merges into that flow, a changed trade, a parent with several occupations
- * (only the first counts), a father → daughter flow and a mother → daughter
- * flow (both parents are considered, regardless of sex), a child of two working
- * parents that feeds two distinct flows, and four kinds of pair that must be
- * dropped — a parent without an occupation, a child without an occupation, a
- * child with no resolvable parent, and a child whose only recorded parent lacks
- * a trade.
+ * (every trade counts, so the secondary Mayor → Carpenter flow surfaces), a
+ * father → daughter flow and a mother → daughter flow (both parents are
+ * considered, regardless of sex), a child of two working parents that feeds two
+ * distinct flows, and four kinds of pair that must be dropped — a parent without
+ * an occupation, a child without an occupation, a child with no resolvable
+ * parent, and a child whose only recorded parent lacks a trade. A dedicated
+ * fixture exercises the full parent × child cross-product when both sides carry
+ * several trades.
  *
  * @author  Rico Sonntag <mail@ricosonntag.de>
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
@@ -63,13 +65,14 @@ use function array_unique;
 final class OccupationInheritanceRepositoryIntegrationTest extends AbstractIntegrationTestCase
 {
     /**
-     * Aggregates the fixture into the bipartite Sankey payload. Seven flows
+     * Aggregates the fixture into the bipartite Sankey payload. Eight flows
      * survive: Farmer → Farmer (×5, four direct children plus the case-folded
-     * `farmer`/`FARMER` pair), Blacksmith → Farmer (×1), Carpenter → Carpenter
-     * (×1), Weaver → Weaver (×1, a father → daughter), Seamstress → Seamstress
-     * (×1, a mother → daughter), and Mason → Glazier plus Potter → Glazier (×1
-     * each, the two trades of a child's working father and mother). Every
-     * dropped pair stays out of the result.
+     * `farmer`/`FARMER` pair), Carpenter → Carpenter (×1), Mayor → Carpenter
+     * (×1, the multi-occupation father's secondary trade), Weaver → Weaver (×1,
+     * a father → daughter), Seamstress → Seamstress (×1, a mother → daughter),
+     * Mason → Glazier plus Potter → Glazier (×1 each, the two trades of a child's
+     * working father and mother) and Blacksmith → Farmer (×1). Every dropped pair
+     * stays out of the result.
      */
     #[Test]
     public function occupationInheritanceReturnsTheExpectedAggregation(): void
@@ -78,42 +81,44 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
             ->occupationInheritance(10);
 
-        // Seven distinct flows survive.
-        self::assertCount(7, $result->links);
+        // Eight distinct flows survive.
+        self::assertCount(8, $result->links);
 
         // Source column then target column, each in encounter order over the
         // weight-sorted flows. Equal-weight flows keep their insertion order,
-        // which follows the lexicographic xref scan (I1, I10, …, I2, …, I9), so
-        // the single Blacksmith → Farmer pair (child I9) lands last.
+        // which follows the lexicographic xref scan (I1, I10, …, I2, …, I9): the
+        // multi-occupation father I10 is scanned via his son I11 first, so
+        // Carpenter then Mayor lead the weight-1 sources, and the single
+        // Blacksmith → Farmer pair (child I9) lands last.
         self::assertSame(
             [
-                'Farmer', 'Carpenter', 'Weaver', 'Seamstress', 'Mason', 'Potter', 'Blacksmith',
+                'Farmer', 'Carpenter', 'Mayor', 'Weaver', 'Seamstress', 'Mason', 'Potter', 'Blacksmith',
                 'Farmer', 'Carpenter', 'Weaver', 'Seamstress', 'Glazier',
             ],
             $result->nodes,
         );
 
         // Heaviest flow leads — Farmer (source idx 0) → Farmer (target idx 0,
-        // shifted by sourceColumnSize=7 to absolute idx 7). Its weight of 5
+        // shifted by sourceColumnSize=8 to absolute idx 8). Its weight of 5
         // proves the case-folded `farmer` / `FARMER` pair merged into the four
         // direct Farmer → Farmer children.
         $heaviest = $result->links[0];
         self::assertSame(0, $heaviest->source);
-        self::assertSame(7, $heaviest->target);
+        self::assertSame(8, $heaviest->target);
         self::assertSame(5, $heaviest->value);
 
-        // The six remaining flows weigh 1 each.
+        // The seven remaining flows weigh 1 each.
         $tailValues = array_map(
             static fn (SankeyLink $link): int => $link->value,
             array_slice($result->links, 1),
         );
-        self::assertSame([1, 1, 1, 1, 1, 1], $tailValues);
+        self::assertSame([1, 1, 1, 1, 1, 1, 1], $tailValues);
 
         // Every link respects the bipartite invariant: source index in the
-        // source column [0, 7), target index in the target column [7, 12).
+        // source column [0, 8), target index in the target column [8, 13).
         foreach ($result->links as $link) {
-            self::assertLessThan(7, $link->source, 'source index must be in the source column');
-            self::assertGreaterThanOrEqual(7, $link->target, 'target index must be in the target column');
+            self::assertLessThan(8, $link->source, 'source index must be in the source column');
+            self::assertGreaterThanOrEqual(8, $link->target, 'target index must be in the target column');
         }
     }
 
@@ -197,21 +202,81 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     }
 
     /**
-     * A parent carrying several `1 OCCU` lines contributes only their FIRST
-     * recorded trade — pairing every parent trade against the child would
-     * inflate one succession into a cross-product. The fixture's
-     * multi-occupation father lists Carpenter before Mayor, so Carpenter is the
-     * source node and Mayor never appears.
+     * A parent carrying several `1 OCCU` lines contributes EVERY recorded trade,
+     * not just the first: each parent occupation is paired against the child's
+     * occupation. The fixture's multi-occupation father lists Carpenter before
+     * Mayor and his son is a Carpenter, so both Carpenter → Carpenter and
+     * Mayor → Carpenter surface — the secondary trade is no longer dropped.
      */
     #[Test]
-    public function occupationInheritanceReadsOnlyThePrimaryParentOccupation(): void
+    public function occupationInheritanceReadsEveryParentOccupation(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
             ->occupationInheritance(10);
 
-        self::assertContains('Carpenter', $result->nodes);
-        self::assertNotContains('Mayor', $result->nodes, 'only the first parent OCCU counts');
+        $flows = $this->flowLabels($result);
+
+        self::assertContains(['Carpenter', 'Carpenter'], $flows, 'the primary parent trade is counted');
+        self::assertContains(['Mayor', 'Carpenter'], $flows, 'the secondary parent trade is counted too');
+    }
+
+    /**
+     * A parent and a child that each record several `1 OCCU` lines produce the
+     * full cross-product of (parent trade → child trade): every parent
+     * occupation is paired against every child occupation, so a secondary trade
+     * surfaces both as a source and as a target. The fixture's father and son
+     * are each a Farmer AND a Carter, yielding all four combinations —
+     * Farmer → Farmer, Farmer → Carter, Carter → Farmer and Carter → Carter —
+     * each weighing one. The former first-OCCU-only behaviour produced only the
+     * single Farmer → Farmer flow.
+     */
+    #[Test]
+    public function occupationInheritanceCountsTheFullCrossProductOfMultipleOccupations(): void
+    {
+        $tree   = $this->importFixtureTree('occupation-inheritance-multi-occupation.ged');
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+            ->occupationInheritance(10);
+
+        self::assertCount(4, $result->links, 'two 2-trade people yield the 2×2 cross-product');
+
+        $flows = $this->flowLabels($result);
+
+        self::assertContains(['Farmer', 'Farmer'], $flows);
+        self::assertContains(['Farmer', 'Carter'], $flows);
+        self::assertContains(['Carter', 'Farmer'], $flows);
+        self::assertContains(['Carter', 'Carter'], $flows);
+
+        foreach ($result->links as $link) {
+            self::assertSame(1, $link->value, 'each distinct cross-product flow is counted once');
+        }
+    }
+
+    /**
+     * A trade repeated across several of a person's own `1 OCCU` lines counts as
+     * one distinct trade, not once per duplicate line: the repository folds each
+     * person's occupations to their distinct trades before pairing, so neither
+     * the flow count nor a flow's weight inflates. The fixture's father records
+     * Farmer three times plus Carter, and his son records Farmer twice; the
+     * result is exactly two flows — Farmer → Farmer and Carter → Farmer — each
+     * weighing one, never Farmer → Farmer ×3 or a duplicate band.
+     */
+    #[Test]
+    public function occupationInheritanceFoldsRepeatedOccupationLinesToDistinctTrades(): void
+    {
+        $tree   = $this->importFixtureTree('occupation-inheritance-duplicate-occupation.ged');
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+            ->occupationInheritance(10);
+
+        self::assertCount(2, $result->links, 'repeated occupation lines must not create duplicate flows');
+        self::assertSame(
+            [['Farmer', 'Farmer'], ['Carter', 'Farmer']],
+            $this->flowLabels($result),
+        );
+
+        foreach ($result->links as $link) {
+            self::assertSame(1, $link->value, 'a repeated trade must not inflate the flow weight');
+        }
     }
 
     /**

--- a/tests/fixtures/occupation-inheritance-duplicate-occupation.ged
+++ b/tests/fixtures/occupation-inheritance-duplicate-occupation.ged
@@ -1,0 +1,29 @@
+0 HEAD
+1 SOUR webtrees-statistics-fixture
+2 NAME occupation-inheritance-duplicate-occupation
+1 DEST ANSTFILE
+1 CHAR UTF-8
+1 SUBM @SUBM1@
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+0 @SUBM1@ SUBM
+1 NAME Fixture
+0 @I1@ INDI
+1 NAME Hans /Repeated/
+1 SEX M
+1 OCCU Farmer
+1 OCCU Farmer
+1 OCCU Farmer
+1 OCCU Carter
+1 FAMS @F1@
+0 @I2@ INDI
+1 NAME Emil /Repeated/
+1 SEX M
+1 OCCU Farmer
+1 OCCU Farmer
+1 FAMC @F1@
+0 @F1@ FAM
+1 HUSB @I1@
+1 CHIL @I2@
+0 TRLR

--- a/tests/fixtures/occupation-inheritance-multi-occupation.ged
+++ b/tests/fixtures/occupation-inheritance-multi-occupation.ged
@@ -1,0 +1,27 @@
+0 HEAD
+1 SOUR webtrees-statistics-fixture
+2 NAME occupation-inheritance-multi-occupation
+1 DEST ANSTFILE
+1 CHAR UTF-8
+1 SUBM @SUBM1@
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+0 @SUBM1@ SUBM
+1 NAME Fixture
+0 @I1@ INDI
+1 NAME Hans /Doubletrade/
+1 SEX M
+1 OCCU Farmer
+1 OCCU Carter
+1 FAMS @F1@
+0 @I2@ INDI
+1 NAME Emil /Doubletrade/
+1 SEX M
+1 OCCU Farmer
+1 OCCU Carter
+1 FAMC @F1@
+0 @F1@ FAM
+1 HUSB @I1@
+1 CHIL @I2@
+0 TRLR


### PR DESCRIPTION
## Summary

Closes #216.

The parent → child occupation Sankey read only the **first** `1 OCCU` line per
person, so a secondary trade recorded on its own line was silently dropped: a
person listed as `Bauer` and then `Anspanner` contributed only `Bauer`, and the
second trade never appeared as a node — even though it is genuinely passed down
or inherited. In a real tree a substantial share of occupation-bearing
individuals carry more than one `1 OCCU` line, so those trades were simply
invisible.

## Change

- **Read every `1 OCCU` line** per person and count the full **cross-product** of
  (parent trade → child trade), so a secondary occupation surfaces as both a
  source and a target. Each distinct pair is still counted **once per child**, so
  two parents sharing a trade never double a band.
- **Deduplicate up front** — a new `uniqueTrades()` helper folds each person's
  occupations to their DISTINCT case-folded trades (first-seen casing wins). A
  trade repeated across several `1 OCCU` lines counts once and casing variants
  merge, which also **bounds the cross-product** to the handful of trades a
  person actually holds rather than the raw line count.
- **Composite values are deliberately NOT split** — `Trade A und Trade B` on one
  line stays a single trade; recording distinct trades on separate lines is the
  supported form. Occupation-string normalization/standardization stays out of
  scope for this module.

## Tests

- A dedicated cross-product fixture (parent and child each `Farmer` + `Carter`)
  asserts the full 2×2 = 4 flows — verified red against the previous
  first-OCCU-only code (1 flow).
- A repeated-line boundary fixture (father `Farmer`×3 + `Carter`, son `Farmer`×2)
  pins that duplicate lines fold to distinct trades with no weight/flow inflation.
- The former `readsOnlyThePrimaryParentOccupation` test (which asserted the
  secondary `Mayor` trade was dropped) is inverted to
  `readsEveryParentOccupation`; the aggregation snapshot is re-derived from the
  new authoritative output (7 → 8 flows, `Mayor → Carpenter` added).

## Notes

No hard per-person occupation cap is imposed: after the dedup the work is
O(distinct trades²), distinct occupations per person are inherently tiny in
genealogy data, and a hard cap would silently drop legitimate trades. The chart
is an authenticated dashboard aggregating the tree's own editor-controlled data.
