### PR TITLE
GH-218: Adapt the occupation-inheritance flow cap to tree density

### DIFF
--- a/dev/profile-tabs.php
+++ b/dev/profile-tabs.php
@@ -136,7 +136,7 @@ $tabs = [
         'getTreeRecords'               => fn () => $statistic->getTreeRecords(),
         'getTotalOccupations'          => fn () => $statistic->getTotalOccupations(),
         'getTopOccupations(10)'        => fn () => $statistic->getTopOccupations(10),
-        'getOccupationInheritance(12)' => fn () => $statistic->getOccupationInheritance(12),
+        'getOccupationInheritance()'   => fn () => $statistic->getOccupationInheritance(),
         'getTotalReligions'            => fn () => $statistic->getTotalReligions(),
         'getTopReligions(10)'          => fn () => $statistic->getTopReligions(10),
     ],

--- a/resources/views/modules/statistics-chart/tabs/overview.phtml
+++ b/resources/views/modules/statistics-chart/tabs/overview.phtml
@@ -32,7 +32,7 @@ $topOccupations   = $statistic->getTopOccupations(10);
 $topReligions     = $statistic->getTopReligions(10);
 $treeRecords      = $statistic->getTreeRecords();
 
-$occupationInheritance = $statistic->getOccupationInheritance(12);
+$occupationInheritance = $statistic->getOccupationInheritance();
 
 $livingDeceased = $statistic->getTotalLivingDeceasedData();
 $livingCount    = $livingDeceased[0]['value'] ?? 0;

--- a/src/Repository/OccupationInheritanceRepository.php
+++ b/src/Repository/OccupationInheritanceRepository.php
@@ -76,6 +76,26 @@ final readonly class OccupationInheritanceRepository
     private const int SAMPLES_PER_FLOW = 3;
 
     /**
+     * Legibility ceiling on the number of flows the Overview diagram renders. A
+     * Sankey beyond roughly this many flows degrades into an unreadable hairball
+     * regardless of tree size, so this is a fixed property of the medium, not of
+     * the data — the adaptive part is {@see self::MIN_FLOW_WEIGHT}, which lets a
+     * sparse tree show fewer flows and a dense one fill up to this cap.
+     */
+    private const int MAX_FLOWS = 15;
+
+    /**
+     * Minimum weight a flow must reach to appear in the Overview diagram. An
+     * inheritance PATTERN requires recurrence: a single parent → child pair is
+     * an anecdote, and the long tail of such one-offs would otherwise swamp the
+     * diagram (in a real tree they outnumber the recurring flows by an order of
+     * magnitude). Dropping everything below this weight is the data-driven floor
+     * that makes the shown-flow count adapt to a tree's density; a tree with no
+     * recurring occupational inheritance yields an honestly empty diagram.
+     */
+    private const int MIN_FLOW_WEIGHT = 2;
+
+    /**
      * @param Tree                $tree      The tree the statistics are computed for
      * @param ParentMapRepository $parentMap Shared child → [father, mother] resolver
      */
@@ -92,8 +112,15 @@ final readonly class OccupationInheritanceRepository
      * full cross-product of their (parent-occupation → child-occupation) pairs is
      * counted, each distinct pair once per child. A child is counted at most once
      * per flow, so two parents sharing the same trade do not double the child
-     * into a single band. Only the top-N links by weight
-     * are returned so the diagram stays legible. The weighted flow map is handed
+     * into a single band.
+     *
+     * Two display thresholds shape what the Overview diagram shows, both
+     * defaulting to the repository's own policy constants. Flows lighter than
+     * `$minWeight` are dropped first — an inheritance pattern must recur across
+     * at least that many children, so the long tail of one-off pairs never reaches
+     * the chart (a tree with no recurring flow yields an empty diagram). The
+     * survivors are then capped at `$maxFlows` by weight so the diagram stays
+     * legible. The weighted flow map is handed
      * to {@see BipartiteSankeyAssembler}, which lays the parent and child sides
      * out as disjoint node columns (a trade that is both passed down and
      * inherited becomes two separate nodes, avoiding the d3-sankey "circular
@@ -103,10 +130,13 @@ final readonly class OccupationInheritanceRepository
      * `xref`) so the consumer's hover tooltip can surface representative people
      * behind every inheritance path.
      *
-     * @param int $topLinks Maximum number of distinct flows to retain
+     * @param int $maxFlows  Legibility ceiling on the number of flows returned
+     * @param int $minWeight Minimum weight a flow must reach to be shown; 1 returns every flow unfiltered
      */
-    public function occupationInheritance(int $topLinks): SankeyFlowsPayload
-    {
+    public function occupationInheritance(
+        int $maxFlows = self::MAX_FLOWS,
+        int $minWeight = self::MIN_FLOW_WEIGHT,
+    ): SankeyFlowsPayload {
         // ORDER BY i_id pins iteration to the (lexicographic) xref order so the
         // SAMPLES_PER_FLOW cap always picks the same representatives across
         // page loads, even after table-level events (OPTIMIZE TABLE,
@@ -237,9 +267,22 @@ final readonly class OccupationInheritanceRepository
             }
         }
 
+        // Drop one-off flows below the display floor: an inheritance pattern
+        // must recur across at least $minWeight children. $minWeight === 1 means
+        // "every flow", so the aggregation stays byte-identical for the
+        // unfiltered call the data-layer tests use. An emptied map assembles to
+        // the empty payload — the honest "no recurring inheritance" diagram.
+        if ($minWeight > 1) {
+            foreach ($linkWeight as $key => $weight) {
+                if ($weight < $minWeight) {
+                    unset($linkWeight[$key], $linkSamples[$key]);
+                }
+            }
+        }
+
         // Occupations were case-folded for counting, so the assembler is given
         // the key → first-seen-casing map to surface readable node labels.
-        return BipartiteSankeyAssembler::assemble($linkWeight, $linkSamples, $topLinks, $display);
+        return BipartiteSankeyAssembler::assemble($linkWeight, $linkSamples, $maxFlows, $display);
     }
 
     /**

--- a/src/Statistic.php
+++ b/src/Statistic.php
@@ -1233,13 +1233,13 @@ final readonly class Statistic
      * Parent → child occupation inheritance flows ready for the Overview-tab
      * Sankey diagram. Each link runs from a parent's occupation to a child's;
      * only children whose father or mother also has a recorded occupation
-     * contribute, and only the top-N weighted links are returned.
-     *
-     * @param int $topLinks Maximum number of distinct flows to retain
+     * contribute. The repository applies its adaptive display policy — one-off
+     * flows are dropped and the survivors are capped at a legibility ceiling, so
+     * the shown-flow count adapts to the tree's density rather than a fixed cap.
      */
-    public function getOccupationInheritance(int $topLinks): SankeyFlowsPayload
+    public function getOccupationInheritance(): SankeyFlowsPayload
     {
-        return $this->occupationInheritanceRepository->occupationInheritance($topLinks);
+        return $this->occupationInheritanceRepository->occupationInheritance();
     }
 
     /**

--- a/tests/Integration/OccupationInheritanceRepositoryIntegrationTest.php
+++ b/tests/Integration/OccupationInheritanceRepositoryIntegrationTest.php
@@ -79,7 +79,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         // Eight distinct flows survive.
         self::assertCount(8, $result->links);
@@ -133,7 +133,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         $flows = $this->flowLabels($result);
 
@@ -159,7 +159,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         $flows = $this->flowLabels($result);
 
@@ -191,7 +191,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('occupation-inheritance-shared-parent-trade.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         self::assertCount(1, $result->links, 'two same-trade parents feed one flow, not two');
         self::assertSame(['Baker', 'Baker'], $result->nodes);
@@ -213,7 +213,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         $flows = $this->flowLabels($result);
 
@@ -236,7 +236,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('occupation-inheritance-multi-occupation.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         self::assertCount(4, $result->links, 'two 2-trade people yield the 2×2 cross-product');
 
@@ -266,7 +266,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('occupation-inheritance-duplicate-occupation.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         self::assertCount(2, $result->links, 'repeated occupation lines must not create duplicate flows');
         self::assertSame(
@@ -289,7 +289,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         // Tailor: child's trade, but his father has no occupation.
         // Miller: father's trade, but his child has none.
@@ -314,7 +314,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         $heaviest = PayloadNarrowing::sankeyLinkAt($result->links, 0);
         self::assertSame(5, $heaviest->value, 'flow weight reflects all 5 contributing children');
@@ -352,11 +352,49 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(1);
+            ->occupationInheritance(1, 1);
 
         self::assertCount(1, $result->links);
         self::assertSame(5, $result->links[0]->value);
         self::assertSame(['Farmer', 'Farmer'], $result->nodes);
+    }
+
+    /**
+     * The Overview display policy keeps only recurring inheritance patterns. The
+     * curated fixture has one recurring flow (Farmer → Farmer ×5) and seven
+     * one-off (weight-1) flows; called with its default policy the aggregator
+     * drops every one-off, so exactly the recurring flow survives. This data
+     * floor lets the shown-flow count adapt to a tree's density instead of a
+     * hard-coded cap.
+     */
+    #[Test]
+    public function occupationInheritanceDropsOneOffFlowsBelowTheMinimumWeight(): void
+    {
+        $tree   = $this->importFixtureTree('occupation-inheritance.ged');
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+            ->occupationInheritance();
+
+        self::assertCount(1, $result->links, 'only the recurring flow survives the min-weight floor');
+        self::assertSame(['Farmer', 'Farmer'], $result->nodes);
+        self::assertSame(5, $result->links[0]->value);
+    }
+
+    /**
+     * A tree whose every occupation flow occurs exactly once carries no
+     * recurring inheritance pattern, so the Overview policy returns an
+     * honestly empty diagram rather than a wall of one-off noise. The
+     * multi-occupation fixture yields four weight-1 cross-product flows, all of
+     * which fall below the minimum weight.
+     */
+    #[Test]
+    public function occupationInheritanceReturnsEmptyWhenNoFlowRecursUnderTheDisplayPolicy(): void
+    {
+        $tree   = $this->importFixtureTree('occupation-inheritance-multi-occupation.ged');
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+            ->occupationInheritance();
+
+        self::assertSame([], $result->nodes);
+        self::assertSame([], $result->links);
     }
 
     /**
@@ -373,7 +411,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('occupation-inheritance-multigeneration.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         // Two flows: Smith → Carpenter (grandfather → father) and Carpenter →
         // Mason (father → son). Carpenter appears once per column.
@@ -404,7 +442,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     {
         $tree   = $this->importFixtureTree('father-son-name-passdown.ged');
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         self::assertSame([], $result->nodes);
         self::assertSame([], $result->links);
@@ -439,7 +477,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
         Auth::logout();
 
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
         $heaviest = PayloadNarrowing::sankeyLinkAt($result->links, 0);
 
         // The flow weight still reflects all four children — dropping a private
@@ -472,7 +510,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
         Auth::logout();
 
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         $tailorToTailor = null;
 
@@ -501,7 +539,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     private function blacksmithFlowSampleNames(Tree $tree): array
     {
         $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
-            ->occupationInheritance(10);
+            ->occupationInheritance(10, 1);
 
         return array_map(
             static fn (SankeySample $sample): string => $sample->name,


### PR DESCRIPTION
## Summary

The Overview-tab parent → child occupation-inheritance Sankey capped its displayed flows at a **hard-coded 12** passed from the template. The flow-weight distribution is highly skewed — a long tail of one-off (weight-1) pairs dominates the flow count — so a fixed top-N truncates a dense tree while padding a sparse one with single-occurrence noise.

This replaces the magic number with an **adaptive display policy**, split into a rendering ceiling and a data floor, both named constants in `OccupationInheritanceRepository`:

- **`MAX_FLOWS` (15)** — a fixed legibility ceiling. A Sankey beyond ~15 flows is an unreadable hairball regardless of tree size; this is a property of the medium, not the data.
- **`MIN_FLOW_WEIGHT` (2)** — drops one-off flows. A flow's weight counts the *children* exhibiting it, so this keeps only patterns that recur across at least two children. This is the data-driven floor that lets the shown-flow count adapt to a tree's density; a tree with no recurring occupational inheritance now yields an **honestly empty** diagram.

Naive alternatives were rejected because they fail on this distribution shape: fraction-of-max is dominated by a single high-weight outlier, and cumulative-coverage/Pareto pulls in nearly the whole tail (the many one-offs are collectively the majority of total weight).

## Design note

`occupationInheritance()` gains `$maxFlows` and `$minWeight` parameters that default to the two constants, so:
- the consumed path (`Statistic::getOccupationInheritance()` → template) applies the policy with **no magic number in the template**;
- the data-layer integration tests pass `minWeight = 1` to exercise the **unfiltered** weighting unchanged (a guarded `if ($minWeight > 1)` keeps that path byte-identical).

## Tests

- Two new integration tests: one asserts one-off flows are dropped (only the recurring flow survives), one asserts the empty-diagram behavior when no flow recurs.
- The 12 existing aggregation tests are unchanged in behavior (explicit `minWeight = 1`).
- Full suite green (phpstan / cgl / rector / 813 unit + MySQL integration). Verified live against a real tree: 15 legible flows, one-off noise dropped.

Closes #218