### PR TITLE
GH-220: Add pluggable occupation normalization seam

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -25,6 +25,15 @@ parameters:
         - %currentWorkingDirectory%/src/
         - %currentWorkingDirectory%/tests/
 
+    # Makes the public surface of the optional occupation-standardization
+    # provider (hartenthaler/hh_occupation_standardizer) discoverable to static
+    # analysis. The module is an optional runtime dependency resolved via
+    # ModuleService and never required by this package, so its classes are not on
+    # the autoload path; scanning this file lets the adapter type-check without
+    # the provider being installed.
+    scanFiles:
+        - %currentWorkingDirectory%/stubs/hh_occupation_standardizer.stub
+
     fileExtensions:
         - php
 

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -1693,7 +1693,7 @@ msgid "Families with vs without children"
 msgstr "Rodiny s dětmi vs. bez dětí"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:350
-#: src/Module.php:337
+#: src/Module.php:352
 msgid "Family"
 msgstr "Rodina"
 
@@ -2206,7 +2206,7 @@ msgid "Life event"
 msgstr "Life event"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:596
-#: src/Module.php:336
+#: src/Module.php:351
 msgid "Life span"
 msgstr "Délka života"
 
@@ -2465,7 +2465,7 @@ msgstr "Vícečetné porody"
 msgid "Multiple-birth rate by century"
 msgstr "Míra vícečetných porodů podle století"
 
-#: src/Module.php:335
+#: src/Module.php:350
 msgid "Names"
 msgstr "Jména"
 
@@ -2594,7 +2594,7 @@ msgstr ""
 msgid "Outlier marriages"
 msgstr ""
 
-#: src/Module.php:334
+#: src/Module.php:349
 msgid "Overview"
 msgstr "Přehled"
 
@@ -2663,7 +2663,7 @@ msgid "Pisces"
 msgstr "Ryby"
 
 #: resources/views/modules/statistics-chart/tabs/places.phtml:232
-#: src/Module.php:338
+#: src/Module.php:353
 msgid "Places"
 msgstr "Místa"
 
@@ -2892,7 +2892,7 @@ msgstr ""
 msgid "Spanish Civil War and post-war years (1936–1942)"
 msgstr ""
 
-#: src/Module.php:108
+#: src/Module.php:123
 msgid "Statistics"
 msgstr "Statistika"
 
@@ -3101,7 +3101,7 @@ msgstr "Tradice"
 msgid "Tree growth over time"
 msgstr "Růst stromu v čase"
 
-#: src/Module.php:339
+#: src/Module.php:354
 msgid "Tree health"
 msgstr "Stav stromu"
 
@@ -3153,7 +3153,7 @@ msgstr "Do %s. let"
 msgid "Up to the end of the %s"
 msgstr "Do konce %s. let"
 
-#: src/Module.php:120
+#: src/Module.php:135
 msgid "Various statistics charts."
 msgstr "Různé statistické diagramy."
 

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -1656,7 +1656,7 @@ msgid "Families with vs without children"
 msgstr "Familier med vs. uden børn"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:350
-#: src/Module.php:337
+#: src/Module.php:352
 msgid "Family"
 msgstr "Familie"
 
@@ -2171,7 +2171,7 @@ msgid "Life event"
 msgstr "Life event"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:596
-#: src/Module.php:336
+#: src/Module.php:351
 msgid "Life span"
 msgstr "Levetid"
 
@@ -2430,7 +2430,7 @@ msgstr "Flerlingefødsler"
 msgid "Multiple-birth rate by century"
 msgstr "Hyppighed af flerlingefødsler pr. århundrede"
 
-#: src/Module.php:335
+#: src/Module.php:350
 msgid "Names"
 msgstr "Navne"
 
@@ -2560,7 +2560,7 @@ msgstr ""
 msgid "Outlier marriages"
 msgstr ""
 
-#: src/Module.php:334
+#: src/Module.php:349
 msgid "Overview"
 msgstr "Oversigt"
 
@@ -2629,7 +2629,7 @@ msgid "Pisces"
 msgstr "Fiskene"
 
 #: resources/views/modules/statistics-chart/tabs/places.phtml:232
-#: src/Module.php:338
+#: src/Module.php:353
 msgid "Places"
 msgstr "Steder"
 
@@ -2857,7 +2857,7 @@ msgstr ""
 msgid "Spanish Civil War and post-war years (1936–1942)"
 msgstr ""
 
-#: src/Module.php:108
+#: src/Module.php:123
 msgid "Statistics"
 msgstr "Statistik"
 
@@ -3066,7 +3066,7 @@ msgstr "Tradition"
 msgid "Tree growth over time"
 msgstr "Stamtræets vækst over tid"
 
-#: src/Module.php:339
+#: src/Module.php:354
 msgid "Tree health"
 msgstr "Træets tilstand"
 
@@ -3118,7 +3118,7 @@ msgstr "Op til %serne"
 msgid "Up to the end of the %s"
 msgstr "Til slutningen af %serne"
 
-#: src/Module.php:120
+#: src/Module.php:135
 msgid "Various statistics charts."
 msgstr "Diverse statistik diagrammer."
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -1770,7 +1770,7 @@ msgid "Families with vs without children"
 msgstr "Familien mit vs. ohne Kinder"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:350
-#: src/Module.php:337
+#: src/Module.php:352
 msgid "Family"
 msgstr "Familie"
 
@@ -2335,7 +2335,7 @@ msgid "Life event"
 msgstr "Lebensereignis"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:596
-#: src/Module.php:336
+#: src/Module.php:351
 msgid "Life span"
 msgstr "Lebensdauer"
 
@@ -2595,7 +2595,7 @@ msgstr "Mehrlinge"
 msgid "Multiple-birth rate by century"
 msgstr "Mehrlingsrate pro Jahrhundert"
 
-#: src/Module.php:335
+#: src/Module.php:350
 msgid "Names"
 msgstr "Namen"
 
@@ -2723,7 +2723,7 @@ msgstr "Sonstige"
 msgid "Outlier marriages"
 msgstr "Ausreißerehen"
 
-#: src/Module.php:334
+#: src/Module.php:349
 msgid "Overview"
 msgstr "Übersicht"
 
@@ -2804,7 +2804,7 @@ msgid "Pisces"
 msgstr "Fische"
 
 #: resources/views/modules/statistics-chart/tabs/places.phtml:232
-#: src/Module.php:338
+#: src/Module.php:353
 msgid "Places"
 msgstr "Orte"
 
@@ -3039,7 +3039,7 @@ msgstr "Sowjetische Hungersnot von 1930–1933"
 msgid "Spanish Civil War and post-war years (1936–1942)"
 msgstr "Spanischer Bürgerkrieg und Nachkriegsjahre (1936–1942)"
 
-#: src/Module.php:108
+#: src/Module.php:123
 msgid "Statistics"
 msgstr "Statistiken"
 
@@ -3282,7 +3282,7 @@ msgstr "Tradition"
 msgid "Tree growth over time"
 msgstr "Stammbaumwachstum über die Zeit"
 
-#: src/Module.php:339
+#: src/Module.php:354
 msgid "Tree health"
 msgstr "Stammbaumqualität"
 
@@ -3341,7 +3341,7 @@ msgstr "Bis zu den %ser Jahren"
 msgid "Up to the end of the %s"
 msgstr "Bis Ende der %ser Jahre"
 
-#: src/Module.php:120
+#: src/Module.php:135
 msgid "Various statistics charts."
 msgstr "Verschiedene Statistikdiagramme."
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -1657,7 +1657,7 @@ msgid "Families with vs without children"
 msgstr "Families with vs without children"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:350
-#: src/Module.php:337
+#: src/Module.php:352
 msgid "Family"
 msgstr "Family"
 
@@ -2159,7 +2159,7 @@ msgid "Life event"
 msgstr "Life event"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:596
-#: src/Module.php:336
+#: src/Module.php:351
 msgid "Life span"
 msgstr "Life span"
 
@@ -2418,7 +2418,7 @@ msgstr "Multiple births"
 msgid "Multiple-birth rate by century"
 msgstr "Multiple-birth rate by century"
 
-#: src/Module.php:335
+#: src/Module.php:350
 msgid "Names"
 msgstr "Names"
 
@@ -2547,7 +2547,7 @@ msgstr ""
 msgid "Outlier marriages"
 msgstr ""
 
-#: src/Module.php:334
+#: src/Module.php:349
 msgid "Overview"
 msgstr "Overview"
 
@@ -2616,7 +2616,7 @@ msgid "Pisces"
 msgstr "Pisces"
 
 #: resources/views/modules/statistics-chart/tabs/places.phtml:232
-#: src/Module.php:338
+#: src/Module.php:353
 msgid "Places"
 msgstr "Places"
 
@@ -2845,7 +2845,7 @@ msgstr ""
 msgid "Spanish Civil War and post-war years (1936–1942)"
 msgstr ""
 
-#: src/Module.php:108
+#: src/Module.php:123
 msgid "Statistics"
 msgstr "Statistics"
 
@@ -3054,7 +3054,7 @@ msgstr "Migration"
 msgid "Tree growth over time"
 msgstr "Tree growth over time"
 
-#: src/Module.php:339
+#: src/Module.php:354
 msgid "Tree health"
 msgstr "Tree health"
 
@@ -3106,7 +3106,7 @@ msgstr "Up to the %ss"
 msgid "Up to the end of the %s"
 msgstr "Up to the end of the %ss"
 
-#: src/Module.php:120
+#: src/Module.php:135
 msgid "Various statistics charts."
 msgstr "Various statistics charts."
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -1665,7 +1665,7 @@ msgid "Families with vs without children"
 msgstr "Familles avec vs sans enfants"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:350
-#: src/Module.php:337
+#: src/Module.php:352
 msgid "Family"
 msgstr "Famille"
 
@@ -2184,7 +2184,7 @@ msgid "Life event"
 msgstr "Événement de vie"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:596
-#: src/Module.php:336
+#: src/Module.php:351
 msgid "Life span"
 msgstr "Durée de vie"
 
@@ -2446,7 +2446,7 @@ msgstr "Naissances multiples"
 msgid "Multiple-birth rate by century"
 msgstr "Taux de naissances multiples par siècle"
 
-#: src/Module.php:335
+#: src/Module.php:350
 msgid "Names"
 msgstr "Noms"
 
@@ -2579,7 +2579,7 @@ msgstr ""
 msgid "Outlier marriages"
 msgstr ""
 
-#: src/Module.php:334
+#: src/Module.php:349
 msgid "Overview"
 msgstr "Vue d'ensemble"
 
@@ -2648,7 +2648,7 @@ msgid "Pisces"
 msgstr "Poissons"
 
 #: resources/views/modules/statistics-chart/tabs/places.phtml:232
-#: src/Module.php:338
+#: src/Module.php:353
 msgid "Places"
 msgstr "Lieux"
 
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "Spanish Civil War and post-war years (1936–1942)"
 msgstr ""
 
-#: src/Module.php:108
+#: src/Module.php:123
 msgid "Statistics"
 msgstr "Statistiques"
 
@@ -3090,7 +3090,7 @@ msgstr "Tradition"
 msgid "Tree growth over time"
 msgstr "Croissance de l'arbre dans le temps"
 
-#: src/Module.php:339
+#: src/Module.php:354
 msgid "Tree health"
 msgstr "Santé de l'arbre"
 
@@ -3142,7 +3142,7 @@ msgstr "Jusqu'aux années %s"
 msgid "Up to the end of the %s"
 msgstr "Jusqu'à la fin des années %s"
 
-#: src/Module.php:120
+#: src/Module.php:135
 msgid "Various statistics charts."
 msgstr "Divers tableaux statistiques."
 

--- a/resources/lang/it/messages.po
+++ b/resources/lang/it/messages.po
@@ -1663,7 +1663,7 @@ msgid "Families with vs without children"
 msgstr "Famiglie con vs senza figli"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:350
-#: src/Module.php:337
+#: src/Module.php:352
 msgid "Family"
 msgstr "Famiglia"
 
@@ -2185,7 +2185,7 @@ msgid "Life event"
 msgstr "Evento di vita"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:596
-#: src/Module.php:336
+#: src/Module.php:351
 msgid "Life span"
 msgstr "Durata della vita"
 
@@ -2446,7 +2446,7 @@ msgstr "Parti plurigemellari"
 msgid "Multiple-birth rate by century"
 msgstr "Tasso di parti plurigemellari per secolo"
 
-#: src/Module.php:335
+#: src/Module.php:350
 msgid "Names"
 msgstr "Nomi"
 
@@ -2578,7 +2578,7 @@ msgstr ""
 msgid "Outlier marriages"
 msgstr ""
 
-#: src/Module.php:334
+#: src/Module.php:349
 msgid "Overview"
 msgstr "Panoramica"
 
@@ -2646,7 +2646,7 @@ msgid "Pisces"
 msgstr "Pesci"
 
 #: resources/views/modules/statistics-chart/tabs/places.phtml:232
-#: src/Module.php:338
+#: src/Module.php:353
 msgid "Places"
 msgstr "Luoghi"
 
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "Spanish Civil War and post-war years (1936–1942)"
 msgstr ""
 
-#: src/Module.php:108
+#: src/Module.php:123
 msgid "Statistics"
 msgstr "Statistiche"
 
@@ -3087,7 +3087,7 @@ msgstr "Tradizione"
 msgid "Tree growth over time"
 msgstr "Crescita dell'albero nel tempo"
 
-#: src/Module.php:339
+#: src/Module.php:354
 msgid "Tree health"
 msgstr "Salute dell'albero"
 
@@ -3139,7 +3139,7 @@ msgstr "Fino agli anni %s"
 msgid "Up to the end of the %s"
 msgstr "Fino alla fine degli anni %s"
 
-#: src/Module.php:120
+#: src/Module.php:135
 msgid "Various statistics charts."
 msgstr "Grafici su varie statistiche."
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -1655,7 +1655,7 @@ msgid "Families with vs without children"
 msgstr "Familier med vs. uten barn"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:350
-#: src/Module.php:337
+#: src/Module.php:352
 msgid "Family"
 msgstr "Familie"
 
@@ -2170,7 +2170,7 @@ msgid "Life event"
 msgstr "Life event"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:596
-#: src/Module.php:336
+#: src/Module.php:351
 msgid "Life span"
 msgstr "Levetid"
 
@@ -2429,7 +2429,7 @@ msgstr "Flerlingefødsler"
 msgid "Multiple-birth rate by century"
 msgstr "Flerlingefødsler per århundre"
 
-#: src/Module.php:335
+#: src/Module.php:350
 msgid "Names"
 msgstr "Navn"
 
@@ -2559,7 +2559,7 @@ msgstr ""
 msgid "Outlier marriages"
 msgstr ""
 
-#: src/Module.php:334
+#: src/Module.php:349
 msgid "Overview"
 msgstr "Oversikt"
 
@@ -2628,7 +2628,7 @@ msgid "Pisces"
 msgstr "Fiskene"
 
 #: resources/views/modules/statistics-chart/tabs/places.phtml:232
-#: src/Module.php:338
+#: src/Module.php:353
 msgid "Places"
 msgstr "Steder"
 
@@ -2856,7 +2856,7 @@ msgstr ""
 msgid "Spanish Civil War and post-war years (1936–1942)"
 msgstr ""
 
-#: src/Module.php:108
+#: src/Module.php:123
 msgid "Statistics"
 msgstr "Statistikk"
 
@@ -3065,7 +3065,7 @@ msgstr "Tradisjon"
 msgid "Tree growth over time"
 msgstr "Stamtreets vekst over tid"
 
-#: src/Module.php:339
+#: src/Module.php:354
 msgid "Tree health"
 msgstr "Stamtreets tilstand"
 
@@ -3117,7 +3117,7 @@ msgstr "Opp til %s-årene"
 msgid "Up to the end of the %s"
 msgstr "Til slutten av %s-årene"
 
-#: src/Module.php:120
+#: src/Module.php:135
 msgid "Various statistics charts."
 msgstr "Ulike statistikkdiagram."
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -1782,7 +1782,7 @@ msgid "Families with vs without children"
 msgstr "Gezinnen met vs. zonder kinderen"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:350
-#: src/Module.php:337
+#: src/Module.php:352
 msgid "Family"
 msgstr "Gezin"
 
@@ -2354,7 +2354,7 @@ msgid "Life event"
 msgstr "Levensgebeurtenis"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:596
-#: src/Module.php:336
+#: src/Module.php:351
 msgid "Life span"
 msgstr "Levensduur"
 
@@ -2615,7 +2615,7 @@ msgstr "Meerlinggeboorten"
 msgid "Multiple-birth rate by century"
 msgstr "Meerlinggeboorten per eeuw"
 
-#: src/Module.php:335
+#: src/Module.php:350
 msgid "Names"
 msgstr "Namen"
 
@@ -2748,7 +2748,7 @@ msgstr "Overig"
 msgid "Outlier marriages"
 msgstr "Uitbijterhuwelijken"
 
-#: src/Module.php:334
+#: src/Module.php:349
 msgid "Overview"
 msgstr "Overzicht"
 
@@ -2829,7 +2829,7 @@ msgid "Pisces"
 msgstr "Vissen"
 
 #: resources/views/modules/statistics-chart/tabs/places.phtml:232
-#: src/Module.php:338
+#: src/Module.php:353
 msgid "Places"
 msgstr "Plaatsen"
 
@@ -3063,7 +3063,7 @@ msgstr "Sovjet-hongersnood van 1930–1933"
 msgid "Spanish Civil War and post-war years (1936–1942)"
 msgstr "Spaanse Burgeroorlog en naoorlogse jaren (1936–1942)"
 
-#: src/Module.php:108
+#: src/Module.php:123
 msgid "Statistics"
 msgstr "Statistieken"
 
@@ -3307,7 +3307,7 @@ msgstr "Traditie"
 msgid "Tree growth over time"
 msgstr "Stamboomgroei over de tijd"
 
-#: src/Module.php:339
+#: src/Module.php:354
 msgid "Tree health"
 msgstr "Stamboomkwaliteit"
 
@@ -3366,7 +3366,7 @@ msgstr "Tot de jaren %s"
 msgid "Up to the end of the %s"
 msgstr "Tot het einde van de jaren %s"
 
-#: src/Module.php:120
+#: src/Module.php:135
 msgid "Various statistics charts."
 msgstr "Diverse statistische grafieken."
 

--- a/resources/lang/pl/messages.po
+++ b/resources/lang/pl/messages.po
@@ -1690,7 +1690,7 @@ msgid "Families with vs without children"
 msgstr "Rodziny z dziećmi vs. bez dzieci"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:350
-#: src/Module.php:337
+#: src/Module.php:352
 msgid "Family"
 msgstr "Rodzina"
 
@@ -2206,7 +2206,7 @@ msgid "Life event"
 msgstr "Life event"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:596
-#: src/Module.php:336
+#: src/Module.php:351
 msgid "Life span"
 msgstr "Długość życia"
 
@@ -2465,7 +2465,7 @@ msgstr "Porody mnogie"
 msgid "Multiple-birth rate by century"
 msgstr "Wskaźnik porodów mnogich według wieku"
 
-#: src/Module.php:335
+#: src/Module.php:350
 msgid "Names"
 msgstr "Nazwiska"
 
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Outlier marriages"
 msgstr ""
 
-#: src/Module.php:334
+#: src/Module.php:349
 msgid "Overview"
 msgstr "Przegląd"
 
@@ -2664,7 +2664,7 @@ msgid "Pisces"
 msgstr "Ryby"
 
 #: resources/views/modules/statistics-chart/tabs/places.phtml:232
-#: src/Module.php:338
+#: src/Module.php:353
 msgid "Places"
 msgstr "Miejsca"
 
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Spanish Civil War and post-war years (1936–1942)"
 msgstr ""
 
-#: src/Module.php:108
+#: src/Module.php:123
 msgid "Statistics"
 msgstr "Statystyki"
 
@@ -3104,7 +3104,7 @@ msgstr "Tradycja"
 msgid "Tree growth over time"
 msgstr "Wzrost drzewa w czasie"
 
-#: src/Module.php:339
+#: src/Module.php:354
 msgid "Tree health"
 msgstr "Kondycja drzewa"
 
@@ -3156,7 +3156,7 @@ msgstr "Do lat %s"
 msgid "Up to the end of the %s"
 msgstr "Do końca lat %s"
 
-#: src/Module.php:120
+#: src/Module.php:135
 msgid "Various statistics charts."
 msgstr "Różne wykresy statystyczne."
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -1700,7 +1700,7 @@ msgid "Families with vs without children"
 msgstr "Семьи с детьми и без"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:350
-#: src/Module.php:337
+#: src/Module.php:352
 msgid "Family"
 msgstr "Семья"
 
@@ -2218,7 +2218,7 @@ msgid "Life event"
 msgstr "Life event"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:596
-#: src/Module.php:336
+#: src/Module.php:351
 msgid "Life span"
 msgstr "Продолжительность жизни"
 
@@ -2477,7 +2477,7 @@ msgstr "Многоплодные роды"
 msgid "Multiple-birth rate by century"
 msgstr "Доля многоплодных родов по векам"
 
-#: src/Module.php:335
+#: src/Module.php:350
 msgid "Names"
 msgstr "Имена"
 
@@ -2607,7 +2607,7 @@ msgstr ""
 msgid "Outlier marriages"
 msgstr ""
 
-#: src/Module.php:334
+#: src/Module.php:349
 msgid "Overview"
 msgstr "Обзор"
 
@@ -2676,7 +2676,7 @@ msgid "Pisces"
 msgstr "Рыбы"
 
 #: resources/views/modules/statistics-chart/tabs/places.phtml:232
-#: src/Module.php:338
+#: src/Module.php:353
 msgid "Places"
 msgstr "Места"
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Spanish Civil War and post-war years (1936–1942)"
 msgstr ""
 
-#: src/Module.php:108
+#: src/Module.php:123
 msgid "Statistics"
 msgstr "Статистика"
 
@@ -3113,7 +3113,7 @@ msgstr "Традиция"
 msgid "Tree growth over time"
 msgstr "Рост древа во времени"
 
-#: src/Module.php:339
+#: src/Module.php:354
 msgid "Tree health"
 msgstr "Состояние дерева"
 
@@ -3165,7 +3165,7 @@ msgstr "До %s-х годов"
 msgid "Up to the end of the %s"
 msgstr "До конца %s-х годов"
 
-#: src/Module.php:120
+#: src/Module.php:135
 msgid "Various statistics charts."
 msgstr "Различные статистические графики."
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -1635,7 +1635,7 @@ msgid "Families with vs without children"
 msgstr "有子女与无子女家庭"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:350
-#: src/Module.php:337
+#: src/Module.php:352
 msgid "Family"
 msgstr "家庭"
 
@@ -2139,7 +2139,7 @@ msgid "Life event"
 msgstr "Life event"
 
 #: resources/views/modules/statistics-chart/tabs/family.phtml:596
-#: src/Module.php:336
+#: src/Module.php:351
 msgid "Life span"
 msgstr "寿命"
 
@@ -2398,7 +2398,7 @@ msgstr "多胞胎"
 msgid "Multiple-birth rate by century"
 msgstr "按世纪的多胞胎出生率"
 
-#: src/Module.php:335
+#: src/Module.php:350
 msgid "Names"
 msgstr "姓名"
 
@@ -2523,7 +2523,7 @@ msgstr ""
 msgid "Outlier marriages"
 msgstr ""
 
-#: src/Module.php:334
+#: src/Module.php:349
 msgid "Overview"
 msgstr "概览"
 
@@ -2592,7 +2592,7 @@ msgid "Pisces"
 msgstr "双鱼座"
 
 #: resources/views/modules/statistics-chart/tabs/places.phtml:232
-#: src/Module.php:338
+#: src/Module.php:353
 msgid "Places"
 msgstr "地点"
 
@@ -2820,7 +2820,7 @@ msgstr ""
 msgid "Spanish Civil War and post-war years (1936–1942)"
 msgstr ""
 
-#: src/Module.php:108
+#: src/Module.php:123
 msgid "Statistics"
 msgstr "统计表"
 
@@ -3029,7 +3029,7 @@ msgstr "传统"
 msgid "Tree growth over time"
 msgstr "族谱随时间的增长"
 
-#: src/Module.php:339
+#: src/Module.php:354
 msgid "Tree health"
 msgstr "族谱质量"
 
@@ -3081,7 +3081,7 @@ msgstr "至 %s 年代"
 msgid "Up to the end of the %s"
 msgstr "至 %s 年代末"
 
-#: src/Module.php:120
+#: src/Module.php:135
 msgid "Various statistics charts."
 msgstr "各种统计图表。"
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -20,6 +20,8 @@ use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\Validator;
 use Fisharebest\Webtrees\View;
 use MagicSunday\Webtrees\ModuleBase\Contract\ModuleAssetUrlInterface;
+use MagicSunday\Webtrees\Statistic\Normalization\Contract\OccupationNormalizerInterface;
+use MagicSunday\Webtrees\Statistic\Normalization\StandardizerModuleNormalizer;
 use MagicSunday\Webtrees\Statistic\Traits\ModuleChartTrait;
 use MagicSunday\Webtrees\Statistic\Traits\ModuleCustomTrait;
 use Override;
@@ -86,7 +88,9 @@ final class Module extends StatisticsChartModule implements ModuleAssetUrlInterf
 
     /**
      * Registers the module's view namespace so AJAX-loaded tab templates can be
-     * resolved by their fully-qualified `<module>::path` names.
+     * resolved by their fully-qualified `<module>::path` names, and binds the
+     * occupation normalizer so the occupation aggregations pick up an installed
+     * standardization provider automatically.
      */
     public function boot(): void
     {
@@ -94,6 +98,17 @@ final class Module extends StatisticsChartModule implements ModuleAssetUrlInterf
             $this->name(),
             realpath($this->resourcesFolder() . 'views/') . '/'
         );
+
+        // Bind the occupation normalizer to the provider-backed adapter. The
+        // adapter degrades to the raw value when no standardization module is
+        // installed, so wiring it is a no-op for sites without one — installing
+        // such a module is the opt-in. The interface has no autowirable
+        // implementation, so the binding must be explicit.
+        $container  = Registry::container();
+        $normalizer = $container->get(StandardizerModuleNormalizer::class);
+        assert($normalizer instanceof StandardizerModuleNormalizer);
+
+        $container->set(OccupationNormalizerInterface::class, $normalizer);
     }
 
     /**

--- a/src/Normalization/Contract/OccupationNormalizerInterface.php
+++ b/src/Normalization/Contract/OccupationNormalizerInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Normalization\Contract;
+
+use MagicSunday\Webtrees\Statistic\Normalization\NormalizedOccupation;
+
+/**
+ * Narrow seam through which the occupation aggregations resolve a raw `1 OCCU`
+ * string to a standardized trade. The module is a CONSUMER of whatever
+ * occupation standardization a site has available — it never owns the data. The
+ * default implementation ({@see RawOccupationNormalizer}) is a pure identity
+ * that returns null for everything, so nothing changes until a real provider is
+ * present; the adapter implementation resolves an installed standardization
+ * module in-process.
+ *
+ * A `null` result always means "unknown — keep the raw value", so every call
+ * site falls back to the raw string and no occupation is ever dropped.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+interface OccupationNormalizerInterface
+{
+    /**
+     * Resolve a whole distinct-trade set at once. The occupation aggregations
+     * fold on the batch result, so a provider can initialise its normalization
+     * data a single time instead of once per term. Each input maps to its
+     * standardized trade, or to null when the provider cannot place it (unknown
+     * term, provider absent, status-only value) — null keeps the raw value.
+     *
+     * @param iterable<string> $rawOccupations The distinct raw `1 OCCU` values to resolve
+     * @param string|null      $language       BCP-47 language every value is written in, or null when unknown
+     *
+     * @return array<string, NormalizedOccupation|null> Keyed by each distinct input string; null keeps the raw value
+     */
+    public function normalizeMany(iterable $rawOccupations, ?string $language = null): array;
+}

--- a/src/Normalization/NormalizedOccupation.php
+++ b/src/Normalization/NormalizedOccupation.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Normalization;
+
+/**
+ * The result of resolving one raw `1 OCCU` string to a standardized trade. It
+ * carries exactly the two things the occupation aggregations need — a stable
+ * grouping key so spelling, casing and language variants of the same trade
+ * collapse into one bucket, and a human-readable display label for that bucket
+ * — plus the optional HISCO classification a provider may expose.
+ *
+ * The grouping key and the display label are deliberately separate: two records
+ * of the same trade must fold onto the same {@see self::$groupingKey} even when
+ * their {@see self::$displayLabel} would be rendered differently, and the
+ * display label is chosen for readability, never for identity.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+final readonly class NormalizedOccupation
+{
+    /**
+     * @param string      $groupingKey  Stable identity under which every variant of this trade is counted (e.g. `de:Arzt`)
+     * @param string      $displayLabel Human-readable label shown for the grouped trade (e.g. `Arzt`)
+     * @param string|null $hiscoCode    Optional HISCO classification code, or null when the provider has none
+     * @param float|null  $hiscamScore  Optional HISCAM social-status score, or null when the provider has none
+     */
+    public function __construct(
+        public string $groupingKey,
+        public string $displayLabel,
+        public ?string $hiscoCode = null,
+        public ?float $hiscamScore = null,
+    ) {
+    }
+}

--- a/src/Normalization/OccupationFolding.php
+++ b/src/Normalization/OccupationFolding.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Normalization;
+
+use MagicSunday\Webtrees\Statistic\Normalization\Contract\OccupationNormalizerInterface;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\StringList;
+
+use function mb_strtolower;
+
+/**
+ * Builds the raw-value → (fold key, display label) map both occupation
+ * aggregations fold on. The normalizer is consulted ONCE for the whole distinct
+ * set (so a provider initialises its data a single time), and every value the
+ * provider cannot place falls back to the pre-normalization behaviour: the
+ * case-folded raw string as the key, the raw string as the label. A normalized
+ * value instead folds under its {@see NormalizedOccupation::$groupingKey} and
+ * displays as its {@see NormalizedOccupation::$displayLabel}, so spelling,
+ * casing and language variants of one trade collapse into a single bucket.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+final readonly class OccupationFolding
+{
+    /**
+     * Static-only utility; not constructible.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Resolve every distinct raw `1 OCCU` value to its fold key and display
+     * label. Unknown values keep the pre-normalization fold — case-folded key,
+     * raw label — so no occupation is ever lost.
+     *
+     * @param iterable<string>              $rawValues  The distinct raw `1 OCCU` values to resolve
+     * @param OccupationNormalizerInterface $normalizer The provider consulted once for the whole set
+     * @param string|null                   $language   BCP-47 language the values are written in, or null when unknown
+     *
+     * @return array<string, array{0: string, 1: string}> Raw value => [fold key, display label]
+     */
+    public static function map(iterable $rawValues, OccupationNormalizerInterface $normalizer, ?string $language): array
+    {
+        // Materialise to a string list first: the callers collect the distinct
+        // set as array keys, which coerces a purely numeric value to an int, so
+        // reading the raw values back as strings here is what keeps
+        // mb_strtolower() from throwing under strict types. Materialising also
+        // lets the input be both resolved and iterated without draining a
+        // generator twice.
+        $values     = StringList::of($rawValues);
+        $normalized = $normalizer->normalizeMany($values, $language);
+
+        $folds = [];
+
+        foreach ($values as $rawValue) {
+            $occupation = $normalized[$rawValue] ?? null;
+
+            $folds[$rawValue] = $occupation instanceof NormalizedOccupation
+                ? [$occupation->groupingKey, $occupation->displayLabel]
+                : [mb_strtolower($rawValue), $rawValue];
+        }
+
+        return $folds;
+    }
+}

--- a/src/Normalization/RawOccupationNormalizer.php
+++ b/src/Normalization/RawOccupationNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Normalization;
+
+use MagicSunday\Webtrees\Statistic\Normalization\Contract\OccupationNormalizerInterface;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\StringList;
+
+use function array_fill_keys;
+
+/**
+ * The identity normalizer used when no occupation-standardization provider is
+ * available. It resolves every term to null, which every call site reads as
+ * "unknown — keep the raw value". Wiring this default therefore leaves the
+ * occupation aggregations byte-identical to their pre-normalization behaviour:
+ * raw strings are still folded only by case, exactly as before.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+final readonly class RawOccupationNormalizer implements OccupationNormalizerInterface
+{
+    /**
+     * A null result for every distinct input, keyed by the input string.
+     *
+     * @param iterable<string> $rawOccupations The distinct raw `1 OCCU` values to resolve
+     * @param string|null      $language       Ignored; this normalizer has no language-dependent behaviour
+     *
+     * @return array<string, NormalizedOccupation|null> Every input mapped to null
+     */
+    public function normalizeMany(iterable $rawOccupations, ?string $language = null): array
+    {
+        return array_fill_keys(StringList::of($rawOccupations), null);
+    }
+}

--- a/src/Normalization/StandardizerModuleNormalizer.php
+++ b/src/Normalization/StandardizerModuleNormalizer.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Normalization;
+
+use Fisharebest\Webtrees\Module\ModuleInterface;
+use Fisharebest\Webtrees\Services\ModuleService;
+use Hartenthaler\Webtrees\Module\OccupationStandardizer\PublicApi\OccupationStandardizerInterface;
+use Hartenthaler\Webtrees\Module\OccupationStandardizer\PublicApi\StandardizedOccupation;
+use MagicSunday\Webtrees\Statistic\Normalization\Contract\OccupationNormalizerInterface;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\StringList;
+
+use function array_fill_keys;
+
+/**
+ * Adapter that consumes an installed occupation-standardization module through
+ * its public read-only API. It resolves the active provider once via
+ * webtrees' {@see ModuleService} — matching by the published
+ * {@see OccupationStandardizerInterface} rather than by module name, so it stays
+ * name-independent — and maps the provider's {@see StandardizedOccupation}
+ * result onto this module's own {@see NormalizedOccupation}. When no such module
+ * is installed or enabled, every call resolves to null and the occupation
+ * aggregations keep their raw values unchanged.
+ *
+ * This is the only class that references the provider's contract. The provider's
+ * classes are loaded by the provider module itself at runtime; they are optional
+ * dependencies, so this module never requires them and degrades gracefully when
+ * they are absent.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+final class StandardizerModuleNormalizer implements OccupationNormalizerInterface
+{
+    /**
+     * Whether {@see self::provider()} has already run its one-time lookup.
+     */
+    private bool $resolved = false;
+
+    /**
+     * The resolved provider, or null when none is installed/enabled. Only
+     * meaningful once {@see self::$resolved} is true.
+     */
+    private ?OccupationStandardizerInterface $provider = null;
+
+    /**
+     * @param ModuleService $moduleService Registry of installed webtrees modules used to discover the provider
+     */
+    public function __construct(
+        private readonly ModuleService $moduleService,
+    ) {
+    }
+
+    /**
+     * Resolve the distinct set through the installed provider in one batch and
+     * map each recognized result onto this module's value object. When no
+     * provider is present every input resolves to null, so the caller keeps the
+     * raw value.
+     *
+     * @param iterable<string> $rawOccupations The distinct raw `1 OCCU` values to resolve
+     * @param string|null      $language       BCP-47 language every value is written in, or null when unknown
+     *
+     * @return array<string, NormalizedOccupation|null> Keyed by each distinct input string; null keeps the raw value
+     */
+    public function normalizeMany(iterable $rawOccupations, ?string $language = null): array
+    {
+        $provider = $this->provider();
+
+        if (!$provider instanceof OccupationStandardizerInterface) {
+            return array_fill_keys(StringList::of($rawOccupations), null);
+        }
+
+        $normalized = [];
+
+        foreach ($provider->standardizeMany($rawOccupations, $language) as $rawValue => $standardized) {
+            $normalized[$rawValue] = $standardized instanceof StandardizedOccupation
+                ? $this->toNormalizedOccupation($standardized, $language)
+                : null;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Resolve the active provider once and cache the result — including a null
+     * result, so the lookup does not repeat on a site without the module.
+     */
+    private function provider(): ?OccupationStandardizerInterface
+    {
+        if (!$this->resolved) {
+            $module = $this->moduleService
+                ->all()
+                ->first(static fn (ModuleInterface $module): bool => $module instanceof OccupationStandardizerInterface);
+
+            $this->provider = $module instanceof OccupationStandardizerInterface ? $module : null;
+            $this->resolved = true;
+        }
+
+        return $this->provider;
+    }
+
+    /**
+     * Map the provider's result onto this module's value object. The provider's
+     * language-independent grouping key becomes the fold key, and the display
+     * label is resolved for the tree language in the gender-neutral form (an
+     * aggregated bucket has no single sex).
+     *
+     * @param StandardizedOccupation $standardized The provider's result for one raw value
+     * @param string|null            $language     The tree language passed to the provider, or null when unknown
+     */
+    private function toNormalizedOccupation(StandardizedOccupation $standardized, ?string $language): NormalizedOccupation
+    {
+        return new NormalizedOccupation(
+            $standardized->canonicalKey(),
+            $standardized->displayLabel($language ?? ''),
+            $standardized->hiscoCode(),
+            $standardized->hiscamScore(),
+        );
+    }
+}

--- a/src/Normalization/Support/StringList.php
+++ b/src/Normalization/Support/StringList.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Normalization\Support;
+
+use function array_map;
+use function array_values;
+use function is_array;
+use function iterator_to_array;
+
+/**
+ * Materialises an iterable of raw occupation values into a plain `list<string>`.
+ * Two invariants matter to the normalization seam and are easy to get subtly
+ * wrong if open-coded at each call site: a Traversable is drained exactly once
+ * (so a generator can be both resolved and re-iterated), and every element is
+ * cast back to a string — a purely numeric value (e.g. `1234`) becomes an `int`
+ * the moment it is used as an array key upstream, which would otherwise throw
+ * under strict types when it reaches `mb_strtolower()`.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+final readonly class StringList
+{
+    /**
+     * Static-only utility; not constructible.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Drain the iterable once and return its values as a re-indexed list of
+     * strings.
+     *
+     * @param iterable<int|string> $values The raw values, possibly int-coerced by an upstream array key
+     *
+     * @return list<string> The same values as a plain list, each cast to a string
+     */
+    public static function of(iterable $values): array
+    {
+        $list = is_array($values) ? array_values($values) : iterator_to_array($values, false);
+
+        return array_map(static fn (int|string $value): string => (string) $value, $list);
+    }
+}

--- a/src/Repository/AbstractGedcomTagTopNRepository.php
+++ b/src/Repository/AbstractGedcomTagTopNRepository.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
 
 namespace MagicSunday\Webtrees\Statistic\Repository;
 
+use Closure;
 use Fisharebest\Webtrees\Tree;
+use Illuminate\Support\Collection;
 use MagicSunday\Webtrees\Statistic\Support\Aggregator\TopNAggregator;
 use MagicSunday\Webtrees\Statistic\Support\Database\TreeScope;
 
@@ -70,6 +72,34 @@ abstract class AbstractGedcomTagTopNRepository
     abstract protected function extract(string $gedcom): array;
 
     /**
+     * Optional per-value fold resolver handed to {@see TopNAggregator::topN()}.
+     * The default is `null`, which folds every value by case alone — the exact
+     * behaviour the Top-N counters have always had. A subclass whose values want
+     * standardization (the occupation counter) overrides this to return a
+     * `Closure(string): array{0: string, 1: string}` mapping a raw value to its
+     * [fold key, display label]; the whole individual set is passed so the
+     * override can resolve the distinct values in one batch before the count.
+     *
+     * @param Collection<int, object> $gedcoms The individual GEDCOM rows about to be counted
+     *
+     * @return (Closure(string): array{0: string, 1: string})|null Fold resolver, or null to fold by case alone
+     */
+    protected function foldValue(Collection $gedcoms): ?Closure
+    {
+        return null;
+    }
+
+    /**
+     * The tree the aggregation runs against, exposed to subclasses that need a
+     * tree-scoped input (e.g. the occupation counter's language hint) without
+     * widening the private constructor dependency.
+     */
+    final protected function tree(): Tree
+    {
+        return $this->tree;
+    }
+
+    /**
      * Top-N values by descending frequency. The case-folded aggregation
      * collapses spelling variants under the first-seen casing; the limit caps
      * how many keys make it into the returned slice.
@@ -99,10 +129,17 @@ abstract class AbstractGedcomTagTopNRepository
      */
     private function aggregate(): array
     {
-        return $this->cache ??= TopNAggregator::topN(
-            TreeScope::individualGedcoms($this->tree),
+        if ($this->cache !== null) {
+            return $this->cache;
+        }
+
+        $gedcoms = TreeScope::individualGedcoms($this->tree);
+
+        return $this->cache = TopNAggregator::topN(
+            $gedcoms,
             $this->extract(...),
             0,
+            $this->foldValue($gedcoms),
         );
     }
 }

--- a/src/Repository/NameRepository.php
+++ b/src/Repository/NameRepository.php
@@ -305,7 +305,7 @@ final class NameRepository
         // threshold filter runs after the slice, matching the prior order.
         $givenNames = TopNAggregator::rank(
             $fold['counts'],
-            static fn (string $key): string => GivenNameNormalizer::dominantForm($fold['rawByFold'][$key] ?? []),
+            static fn (int|string $key): string => GivenNameNormalizer::dominantForm($fold['rawByFold'][$key] ?? []),
             $limit,
         );
 

--- a/src/Repository/OccupationInheritanceRepository.php
+++ b/src/Repository/OccupationInheritanceRepository.php
@@ -20,12 +20,15 @@ use Fisharebest\Webtrees\Tree;
 use Illuminate\Database\Query\Builder;
 use MagicSunday\Webtrees\Statistic\Model\Sankey\SankeyFlowsPayload;
 use MagicSunday\Webtrees\Statistic\Model\Sankey\SankeySample;
+use MagicSunday\Webtrees\Statistic\Normalization\Contract\OccupationNormalizerInterface;
+use MagicSunday\Webtrees\Statistic\Normalization\OccupationFolding;
 use MagicSunday\Webtrees\Statistic\Support\Database\TreeScope;
 use MagicSunday\Webtrees\Statistic\Support\Gedcom\GedcomScanner;
 use MagicSunday\Webtrees\Statistic\Support\Gedcom\RowCast;
 use MagicSunday\Webtrees\Statistic\Support\Sankey\BipartiteSankeyAssembler;
 use MagicSunday\Webtrees\Statistic\Support\Sankey\SankeySampleResolver;
 
+use function array_keys;
 use function count;
 use function mb_strtolower;
 
@@ -50,9 +53,11 @@ use function mb_strtolower;
  * string is one trade; recording distinct trades on separate lines is the
  * supported form. Pairs are dropped whenever either side lacks an occupation —
  * the diagram answers "given both worked, did the trade carry over?", so an
- * unknown end would only add noise. Occupations are case-folded before counting
- * so spelling variants (`Smith` / `smith`) merge; the first-seen casing becomes
- * the display label.
+ * unknown end would only add noise. Occupations are folded before counting so
+ * variants of one trade merge into a single flow: casing (`Smith` / `smith`)
+ * always, and — when an occupation-standardization provider is installed —
+ * spelling and language variants too (see {@see OccupationFolding}); the
+ * first-seen label of a fold becomes its display label.
  *
  * Privacy contract (matching the sibling migration Sankey): occupation node
  * labels are AGGREGATE facts and are not individually privacy-gated — a trade
@@ -96,12 +101,14 @@ final readonly class OccupationInheritanceRepository
     private const int MIN_FLOW_WEIGHT = 2;
 
     /**
-     * @param Tree                $tree      The tree the statistics are computed for
-     * @param ParentMapRepository $parentMap Shared child → [father, mother] resolver
+     * @param Tree                          $tree       The tree the statistics are computed for
+     * @param ParentMapRepository           $parentMap  Shared child → [father, mother] resolver
+     * @param OccupationNormalizerInterface $normalizer Resolves raw `1 OCCU` values to standardized trades so variants merge; the identity default leaves the aggregation unchanged
      */
     public function __construct(
         private Tree $tree,
         private ParentMapRepository $parentMap,
+        private OccupationNormalizerInterface $normalizer,
     ) {
     }
 
@@ -161,18 +168,37 @@ final readonly class OccupationInheritanceRepository
             ->select(['i_id AS xref', 'i_gedcom AS gedcom'])
             ->get();
 
-        // First pass: fold every individual's `1 OCCU` lines to their DISTINCT
-        // case-folded trades once, keyed by xref. Parsing here — rather than
-        // again for every child and every parent in the main loop — means a
-        // parent shared by several children is parsed a single time, and the
-        // resident map holds the small trade lists instead of the full GEDCOM
-        // blobs.
-        $tradesByXref = [];
+        // First pass: read every individual's raw `1 OCCU` lines once, keyed by
+        // xref, while collecting the tree-wide DISTINCT set of raw values.
+        // Parsing here — rather than again for every child and every parent in
+        // the main loop — means a parent shared by several children is parsed a
+        // single time, and the resident map holds the small trade lists instead
+        // of the full GEDCOM blobs.
+        $occupationsByXref = [];
+        $distinctRaw       = [];
 
         foreach ($rows as $row) {
-            $tradesByXref[RowCast::string($row, 'xref')] = $this->uniqueTrades(
-                GedcomScanner::extractAllTagValues(RowCast::string($row, 'gedcom'), 'OCCU'),
-            );
+            $occupations                                      = GedcomScanner::extractAllTagValues(RowCast::string($row, 'gedcom'), 'OCCU');
+            $occupationsByXref[RowCast::string($row, 'xref')] = $occupations;
+
+            foreach ($occupations as $occupation) {
+                $distinctRaw[$occupation] = true;
+            }
+        }
+
+        // Resolve the whole distinct set through the normalizer in one batch, so
+        // a standardization provider initialises its data a single time. Every
+        // raw value maps to its (fold key, display label); unknown values keep
+        // the pre-normalization case-fold, so the identity default leaves the
+        // aggregation byte-identical.
+        $folds = OccupationFolding::map(array_keys($distinctRaw), $this->normalizer, TreeScope::languageTag($this->tree));
+
+        // Fold every person's raw values to their DISTINCT trades under the
+        // resolved keys.
+        $tradesByXref = [];
+
+        foreach ($occupationsByXref as $xref => $occupations) {
+            $tradesByXref[$xref] = $this->uniqueTrades($occupations, $folds);
         }
 
         $parentOf = $this->parentMap->build();
@@ -286,23 +312,27 @@ final readonly class OccupationInheritanceRepository
     }
 
     /**
-     * Collapse a person's raw `1 OCCU` values to their DISTINCT trades, keyed by
-     * the case-folded trade and mapped to the first-seen display casing. Reading
+     * Collapse a person's raw `1 OCCU` values to their DISTINCT trades under the
+     * pre-resolved fold map, mapped to the first-seen display label. Reading
      * every OCCU line means a person who records the same trade on several lines
      * would otherwise pair it into the cross-product once per duplicate; folding
      * to distinct trades here bounds the pairing to the trades a person actually
-     * holds and merges casing variants (`Smith` / `smith`) in one place.
+     * holds and merges variants — casing (`Smith` / `smith`), and, once a
+     * standardization provider is present, spelling and language too — that
+     * share a fold key.
      *
-     * @param list<string> $occupations The raw `1 OCCU` values in recorded order
+     * @param list<string>                               $occupations The raw `1 OCCU` values in recorded order
+     * @param array<string, array{0: string, 1: string}> $folds       Raw value → [fold key, display label] from {@see OccupationFolding::map()}
      *
-     * @return array<string, string> Case-folded trade key → first-seen display casing
+     * @return array<string, string> Fold key → first-seen display label
      */
-    private function uniqueTrades(array $occupations): array
+    private function uniqueTrades(array $occupations, array $folds): array
     {
         $trades = [];
 
         foreach ($occupations as $occupation) {
-            $trades[mb_strtolower($occupation)] ??= $occupation;
+            [$key, $label] = $folds[$occupation] ?? [mb_strtolower($occupation), $occupation];
+            $trades[$key] ??= $label;
         }
 
         return $trades;

--- a/src/Repository/OccupationRepository.php
+++ b/src/Repository/OccupationRepository.php
@@ -11,11 +11,28 @@ declare(strict_types=1);
 
 namespace MagicSunday\Webtrees\Statistic\Repository;
 
+use Closure;
+use Fisharebest\Webtrees\Tree;
+use Illuminate\Support\Collection;
+use MagicSunday\Webtrees\Statistic\Normalization\Contract\OccupationNormalizerInterface;
+use MagicSunday\Webtrees\Statistic\Normalization\OccupationFolding;
+use MagicSunday\Webtrees\Statistic\Support\Database\TreeScope;
 use MagicSunday\Webtrees\Statistic\Support\Gedcom\GedcomScanner;
+
+use function array_keys;
+use function is_string;
+use function mb_strtolower;
 
 /**
  * Top-N aggregation over the `1 OCCU` (occupation) facts attached to
  * individuals. Multiple OCCU lines per INDI all contribute.
+ *
+ * Unlike the other Top-N counters, the occupation values are folded through an
+ * {@see OccupationNormalizerInterface} before counting: when a standardization provider
+ * is installed, spelling and language variants of one trade collapse under a
+ * single grouping key instead of fragmenting into separate bars. The identity
+ * default resolves nothing, so without a provider the aggregation folds by case
+ * alone — byte-identical to the plain Top-N behaviour.
  *
  * @author  Rico Sonntag <mail@ricosonntag.de>
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
@@ -23,6 +40,17 @@ use MagicSunday\Webtrees\Statistic\Support\Gedcom\GedcomScanner;
  */
 final class OccupationRepository extends AbstractGedcomTagTopNRepository
 {
+    /**
+     * @param Tree                          $tree       The tree the statistics are computed for
+     * @param OccupationNormalizerInterface $normalizer Resolves raw `1 OCCU` values to standardized trades so variants merge; the identity default leaves the aggregation unchanged
+     */
+    public function __construct(
+        Tree $tree,
+        private readonly OccupationNormalizerInterface $normalizer,
+    ) {
+        parent::__construct($tree);
+    }
+
     /**
      * Harvests every top-level `1 OCCU` line from the INDI record. An
      * individual carrying two recorded occupations contributes two entries to
@@ -35,5 +63,32 @@ final class OccupationRepository extends AbstractGedcomTagTopNRepository
     protected function extract(string $gedcom): array
     {
         return GedcomScanner::extractAllTagValues($gedcom, 'OCCU');
+    }
+
+    /**
+     * Resolve every distinct occupation once through the normalizer, then fold
+     * each counted value under its grouping key and display label. Batching over
+     * the whole tree here means a standardization provider initialises its data
+     * a single time rather than once per counted line.
+     *
+     * @param Collection<int, object> $gedcoms The individual GEDCOM rows about to be counted
+     *
+     * @return Closure(string): array{0: string, 1: string}
+     */
+    protected function foldValue(Collection $gedcoms): Closure
+    {
+        $distinctRaw = [];
+
+        foreach ($gedcoms as $row) {
+            $gedcom = (isset($row->gedcom) && is_string($row->gedcom)) ? $row->gedcom : '';
+
+            foreach ($this->extract($gedcom) as $value) {
+                $distinctRaw[$value] = true;
+            }
+        }
+
+        $folds = OccupationFolding::map(array_keys($distinctRaw), $this->normalizer, TreeScope::languageTag($this->tree()));
+
+        return static fn (string $value): array => $folds[$value] ?? [mb_strtolower($value), $value];
     }
 }

--- a/src/Support/Aggregator/TopNAggregator.php
+++ b/src/Support/Aggregator/TopNAggregator.php
@@ -15,6 +15,7 @@ use Closure;
 use Illuminate\Support\Collection;
 
 use function array_keys;
+use function array_map;
 use function array_slice;
 use function is_string;
 use function mb_strtolower;
@@ -56,13 +57,21 @@ final readonly class TopNAggregator
      * `catholic ` / `CATHOLIC`) merge into a single bucket. The display label
      * is the first-seen original casing; the count returns the merged total.
      *
-     * @param Collection<int, object>       $rows    Result set from a DB::table('individuals')->...->get() call
-     * @param Closure(string): list<string> $extract Returns the list of label values for one row's gedcom blob
-     * @param int                           $limit   Maximum number of entries to return; 0 or negative returns the full list
+     * A `$foldValue` resolver overrides how each raw value maps to its fold key
+     * and display label. Without one (the default) a value folds by case alone —
+     * key `mb_strtolower($value)`, label the first-seen original casing — which
+     * is exactly the behaviour the RELI / CAUS counters rely on. The OCCU counter
+     * supplies a resolver so spelling and language variants of one trade collapse
+     * under a standardization provider's grouping key.
+     *
+     * @param Collection<int, object>                             $rows      Result set from a DB::table('individuals')->...->get() call
+     * @param Closure(string): list<string>                       $extract   Returns the list of label values for one row's gedcom blob
+     * @param int                                                 $limit     Maximum number of entries to return; 0 or negative returns the full list
+     * @param (Closure(string): array{0: string, 1: string})|null $foldValue Maps a raw value to [fold key, display label]; null folds by case alone
      *
      * @return array<string, int> Display label => count, sorted by descending count then case-folded label
      */
-    public static function topN(Collection $rows, Closure $extract, int $limit): array
+    public static function topN(Collection $rows, Closure $extract, int $limit, ?Closure $foldValue = null): array
     {
         $counts  = [];
         $display = [];
@@ -71,13 +80,16 @@ final readonly class TopNAggregator
             $gedcom = (isset($row->gedcom) && is_string($row->gedcom)) ? $row->gedcom : '';
 
             foreach ($extract($gedcom) as $value) {
-                $key          = mb_strtolower($value);
-                $counts[$key] = ($counts[$key] ?? 0) + 1;
-                $display[$key] ??= $value;
+                [$key, $label] = $foldValue instanceof Closure ? $foldValue($value) : [mb_strtolower($value), $value];
+                $counts[$key]  = ($counts[$key] ?? 0) + 1;
+                $display[$key] ??= $label;
             }
         }
 
-        return self::rank($counts, static fn (string $key): string => $display[$key] ?? $key, $limit);
+        // A purely numeric label (e.g. an occupation recorded as `1234`) becomes
+        // an int array key, so the resolver must accept int|string and stringify
+        // the fallback.
+        return self::rank($counts, static fn (int|string $key): string => $display[$key] ?? (string) $key, $limit);
     }
 
     /**
@@ -92,8 +104,8 @@ final readonly class TopNAggregator
      * `topSurnames` cap deliberately keeps its own collation tie-break instead
      * (see #149).
      *
-     * @param array<string, int> $counts Fold key => merged count
-     * @param int                $limit  Maximum number of keys to return; 0 or negative returns the full list
+     * @param array<int|string, int> $counts Fold key => merged count (a purely numeric key is an int)
+     * @param int                    $limit  Maximum number of keys to return; 0 or negative returns the full list
      *
      * @return list<string> The fold keys ordered by descending count then ascending key
      */
@@ -105,14 +117,19 @@ final readonly class TopNAggregator
         // input-dependent order).
         uksort(
             $counts,
-            static function (string $a, string $b) use ($counts): int {
+            // Keys are int|string because PHP coerces a purely numeric fold key
+            // (a numeric occupation label) to an int array key; stringify for the
+            // byte-order tie-break so string keys stay byte-identical.
+            static function (int|string $a, int|string $b) use ($counts): int {
                 $byCount = ($counts[$b] ?? 0) <=> ($counts[$a] ?? 0);
 
-                return $byCount !== 0 ? $byCount : strcmp($a, $b);
+                return $byCount !== 0 ? $byCount : strcmp((string) $a, (string) $b);
             }
         );
 
-        $keys = array_keys($counts);
+        // Stringify the keys so callers get a uniform list<string> even when a
+        // purely numeric fold key was coerced to an int array key.
+        $keys = array_map(static fn (int|string $key): string => (string) $key, array_keys($counts));
 
         if ($limit <= 0) {
             return $keys;
@@ -128,20 +145,56 @@ final readonly class TopNAggregator
      * ranked order and the counts. The tie-break is decided on the fold key, not
      * on the resolved display label.
      *
-     * @param array<string, int>      $counts  Fold key => merged count
-     * @param Closure(string): string $display Resolves a fold key to its display label
-     * @param int                     $limit   Maximum number of entries to return; 0 or negative returns the full list
+     * Two fold keys can resolve to the SAME display label — a normalization
+     * provider may render two distinct grouping keys (`de:Arzt`, `de:Mediziner`)
+     * to one localized label. Their counts are summed into a single label bucket
+     * that is then RANKED by that combined total, so the merged bucket lands at
+     * the position its total earns (a regression that ranked it by whichever
+     * colliding key was encountered first could drop the true top trade out of a
+     * `top($limit)` slice). When `$display` is injective (the case-fold default,
+     * where the key is derived from the label) each key's label-total equals its
+     * own count and no keys collide, so the ranking is identical to ranking the
+     * fold keys directly and the output stays byte-identical.
+     *
+     * @param array<int|string, int>      $counts  Fold key => merged count (a purely numeric key is an int)
+     * @param Closure(int|string): string $display Resolves a fold key to its display label
+     * @param int                         $limit   Maximum number of entries to return; 0 or negative returns the full list
      *
      * @return array<string, int> Display label => count, ordered by descending count then ascending fold key
      */
     public static function rank(array $counts, Closure $display, int $limit): array
     {
-        $out = [];
+        // Sum each fold key's count into its display-label bucket so a label two
+        // keys share is ranked by the combined total.
+        $labelTotals = [];
 
-        foreach (self::rankKeys($counts, $limit) as $key) {
-            $out[$display($key)] = $counts[$key] ?? 0;
+        foreach ($counts as $key => $count) {
+            $label               = $display($key);
+            $labelTotals[$label] = ($labelTotals[$label] ?? 0) + $count;
         }
 
-        return $out;
+        // Rank the fold keys by their label's TOTAL (keeping the engine-independent
+        // fold-key tie-break), then emit each label once at its first — and thus
+        // highest-ranked — occurrence. Ranking the keys rather than the labels
+        // preserves the byte-identical order of the injective default, where a
+        // label's total is just its own key's count.
+        $keyTotals = [];
+
+        foreach (array_keys($counts) as $key) {
+            $keyTotals[$key] = $labelTotals[$display($key)] ?? 0;
+        }
+
+        $out = [];
+
+        foreach (self::rankKeys($keyTotals, 0) as $key) {
+            $label = $display($key);
+            $out[$label] ??= $labelTotals[$label] ?? 0;
+        }
+
+        if ($limit <= 0) {
+            return $out;
+        }
+
+        return array_slice($out, 0, $limit, true);
     }
 }

--- a/src/Support/Database/TreeScope.php
+++ b/src/Support/Database/TreeScope.php
@@ -104,4 +104,17 @@ final readonly class TreeScope
             ->select(['i_gedcom AS gedcom'])
             ->get();
     }
+
+    /**
+     * The tree's configured language as a BCP-47 tag for consumers that need a
+     * language hint (e.g. occupation normalization), or null when the tree has
+     * no language preference set. An empty preference is normalised to null so
+     * callers can treat "unset" uniformly.
+     */
+    public static function languageTag(Tree $tree): ?string
+    {
+        $language = $tree->getPreference('LANGUAGE');
+
+        return $language !== '' ? $language : null;
+    }
 }

--- a/stubs/hh_occupation_standardizer.stub
+++ b/stubs/hh_occupation_standardizer.stub
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * PHPStan stub for the optional occupation-standardization provider
+ * (hartenthaler/hh_occupation_standardizer). The module is an optional runtime
+ * dependency resolved in-process via ModuleService; it is never required by this
+ * package, so its public-API classes are not on this package's autoload path.
+ * This stub declares exactly the public surface {@see StandardizerModuleNormalizer}
+ * consumes, so static analysis can type-check the adapter without the provider
+ * being installed. It mirrors the provider's published contract in
+ * docs/public-api.md.
+ */
+
+declare(strict_types=1);
+
+namespace Hartenthaler\Webtrees\Module\OccupationStandardizer\PublicApi;
+
+interface OccupationStandardizerInterface
+{
+    public function standardize(string $raw_occupation, ?string $language = null): ?StandardizedOccupation;
+
+    /**
+     * @param iterable<string> $raw_occupations
+     *
+     * @return array<string, StandardizedOccupation|null>
+     */
+    public function standardizeMany(iterable $raw_occupations, ?string $language = null): array;
+}
+
+final class StandardizedOccupation
+{
+    public function canonicalLabel(): string
+    {
+    }
+
+    public function canonicalKey(): string
+    {
+    }
+
+    public function displayLabel(string $language, ?string $sex = null): string
+    {
+    }
+
+    public function hiscoCode(): ?string
+    {
+    }
+
+    public function hisclass(): ?string
+    {
+    }
+
+    public function hiscamScore(): ?float
+    {
+    }
+}

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -317,4 +317,41 @@ final class ArchitectureTest
             )
             ->because('Enums are the vocabulary the rest of the module speaks; they cannot depend back into the layers that consume them');
     }
+
+    /**
+     * Every concrete class in the occupation-normalization seam must be `final`
+     * so its contract (identity default, immutable value object, single provider
+     * adapter) cannot be subverted by a subclass. The `OccupationNormalizerInterface`
+     * interface is excluded because `final` is meaningless for an interface — it
+     * is the very extension point the concrete classes seal.
+     */
+    #[TestRule]
+    public function normalizationConcreteClassesAreFinal(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Normalization'))
+            ->excluding(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Normalization\\Contract'))
+            ->should()->beFinal()
+            ->because('Normalization seam classes must be final so their contract cannot be subverted by a subclass');
+    }
+
+    /**
+     * The normalization seam sits below the repositories: repositories fold
+     * their occupation values THROUGH it, never the reverse. It may depend on
+     * the webtrees framework (the adapter resolves the provider via
+     * ModuleService), but a dependency back onto a repository or the facade would
+     * invert the layering and make the seam impossible to test in isolation.
+     */
+    #[TestRule]
+    public function normalizationDoesNotDependOnRepositoryOrFacade(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Normalization'))
+            ->shouldNot()->dependOn()
+            ->classes(
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Repository'),
+                Selector::classname(self::NAMESPACE_ROOT . '\\Statistic'),
+            )
+            ->because('Repositories fold occupation values through the normalization seam; the inverse direction would create a cycle');
+    }
 }

--- a/tests/Integration/OccupationInheritanceRepositoryIntegrationTest.php
+++ b/tests/Integration/OccupationInheritanceRepositoryIntegrationTest.php
@@ -16,6 +16,10 @@ use Fisharebest\Webtrees\Tree;
 use MagicSunday\Webtrees\Statistic\Model\Sankey\SankeyFlowsPayload;
 use MagicSunday\Webtrees\Statistic\Model\Sankey\SankeyLink;
 use MagicSunday\Webtrees\Statistic\Model\Sankey\SankeySample;
+use MagicSunday\Webtrees\Statistic\Normalization\NormalizedOccupation;
+use MagicSunday\Webtrees\Statistic\Normalization\OccupationFolding;
+use MagicSunday\Webtrees\Statistic\Normalization\RawOccupationNormalizer;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\StringList;
 use MagicSunday\Webtrees\Statistic\Repository\OccupationInheritanceRepository;
 use MagicSunday\Webtrees\Statistic\Repository\ParentMapRepository;
 use MagicSunday\Webtrees\Statistic\Support\Database\TreeScope;
@@ -25,6 +29,7 @@ use MagicSunday\Webtrees\Statistic\Support\Gedcom\RowCast;
 use MagicSunday\Webtrees\Statistic\Support\Sankey\BipartiteSankeyAssembler;
 use MagicSunday\Webtrees\Statistic\Support\Sankey\SankeySampleResolver;
 use MagicSunday\Webtrees\Statistic\Test\Support\Narrowing\PayloadNarrowing;
+use MagicSunday\Webtrees\Statistic\Test\Support\Normalization\StubOccupationNormalizer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -62,6 +67,11 @@ use function array_unique;
 #[UsesClass(BipartiteSankeyAssembler::class)]
 #[UsesClass(SankeySampleResolver::class)]
 #[UsesClass(RecordName::class)]
+#[UsesClass(RawOccupationNormalizer::class)]
+#[UsesClass(NormalizedOccupation::class)]
+#[UsesClass(OccupationFolding::class)]
+#[UsesClass(StubOccupationNormalizer::class)]
+#[UsesClass(StringList::class)]
 final class OccupationInheritanceRepositoryIntegrationTest extends AbstractIntegrationTestCase
 {
     /**
@@ -78,7 +88,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceReturnsTheExpectedAggregation(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         // Eight distinct flows survive.
@@ -123,6 +133,48 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     }
 
     /**
+     * When a standardization provider is present, spelling and language variants
+     * of one trade fold into a single flow. The fixture records two separate
+     * father → son Arzt lines, one spelled `Arzt` and one `Doctor`: with the
+     * identity default they stay two distinct weight-1 flows, but a provider that
+     * maps both spellings to the same grouping key collapses them into one
+     * `Arzt → Arzt` flow of weight 2. Asserting both halves pins the merge as the
+     * behavioural difference the normalizer makes — a regression that ignored the
+     * provider would leave two flows and fail the second assertion.
+     */
+    #[Test]
+    public function occupationInheritanceMergesLanguageVariantsThroughTheNormalizer(): void
+    {
+        $tree = $this->importFixtureTree('occupation-inheritance-language-variants.ged');
+
+        // Identity default: the two spellings never merge.
+        $rawResult = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
+            ->occupationInheritance(10, 1);
+
+        self::assertSame(
+            [['Arzt', 'Arzt'], ['Doctor', 'Doctor']],
+            $this->flowLabels($rawResult),
+            'without a provider the two spellings stay separate flows',
+        );
+
+        // A provider that folds `Arzt` and `Doctor` onto one trade merges the two
+        // father → son flows into a single weight-2 flow.
+        $arzt       = new NormalizedOccupation('de:Arzt', 'Arzt');
+        $normalizer = new StubOccupationNormalizer([
+            'Arzt'   => $arzt,
+            'Doctor' => $arzt,
+        ]);
+
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), $normalizer))
+            ->occupationInheritance(10, 1);
+
+        self::assertCount(1, $result->links, 'the two variant flows collapse into one');
+        self::assertSame(['Arzt', 'Arzt'], $result->nodes, 'the merged flow shows the provider display label');
+        self::assertSame(2, $result->links[0]->value, 'the merged flow carries the combined weight');
+        self::assertSame(1, $normalizer->batchCalls(), 'the whole distinct trade set is resolved in one batch');
+    }
+
+    /**
      * Both parents are considered regardless of sex, so a daughter inherits a
      * father's trade (Weaver → Weaver) and a mother's trade reaches her daughter
      * (Seamstress → Seamstress) — the two flows the issue asked for that the
@@ -132,7 +184,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceCountsBothParentSexesAndChildSexes(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         $flows = $this->flowLabels($result);
@@ -158,7 +210,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceCountsBothParentsOfOneChild(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         $flows = $this->flowLabels($result);
@@ -190,7 +242,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceCountsAChildOnceWhenBothParentsShareTheTrade(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance-shared-parent-trade.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         self::assertCount(1, $result->links, 'two same-trade parents feed one flow, not two');
@@ -212,7 +264,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceReadsEveryParentOccupation(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         $flows = $this->flowLabels($result);
@@ -235,7 +287,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceCountsTheFullCrossProductOfMultipleOccupations(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance-multi-occupation.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         self::assertCount(4, $result->links, 'two 2-trade people yield the 2×2 cross-product');
@@ -265,7 +317,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceFoldsRepeatedOccupationLinesToDistinctTrades(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance-duplicate-occupation.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         self::assertCount(2, $result->links, 'repeated occupation lines must not create duplicate flows');
@@ -288,7 +340,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceDropsIncompletePairs(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         // Tailor: child's trade, but his father has no occupation.
@@ -313,7 +365,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceAttachesSampleChildrenPerLink(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         $heaviest = PayloadNarrowing::sankeyLinkAt($result->links, 0);
@@ -351,7 +403,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceRespectsTheTopLinksLimit(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(1, 1);
 
         self::assertCount(1, $result->links);
@@ -371,7 +423,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceDropsOneOffFlowsBelowTheMinimumWeight(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance();
 
         self::assertCount(1, $result->links, 'only the recurring flow survives the min-weight floor');
@@ -390,7 +442,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceReturnsEmptyWhenNoFlowRecursUnderTheDisplayPolicy(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance-multi-occupation.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance();
 
         self::assertSame([], $result->nodes);
@@ -410,7 +462,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceCountsAPersonAsBothChildAndParentAcrossGenerations(): void
     {
         $tree   = $this->importFixtureTree('occupation-inheritance-multigeneration.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         // Two flows: Smith → Carpenter (grandfather → father) and Carpenter →
@@ -441,7 +493,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
     public function occupationInheritanceReturnsEmptyWhenNoOccupationsRecorded(): void
     {
         $tree   = $this->importFixtureTree('father-son-name-passdown.ged');
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         self::assertSame([], $result->nodes);
@@ -476,7 +528,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
         // actually restricts visibility.
         Auth::logout();
 
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
         $heaviest = PayloadNarrowing::sankeyLinkAt($result->links, 0);
 
@@ -509,7 +561,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
 
         Auth::logout();
 
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         $tailorToTailor = null;
@@ -538,7 +590,7 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
      */
     private function blacksmithFlowSampleNames(Tree $tree): array
     {
-        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree)))
+        $result = (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), new RawOccupationNormalizer()))
             ->occupationInheritance(10, 1);
 
         return array_map(

--- a/tests/Integration/OccupationRepositoryIntegrationTest.php
+++ b/tests/Integration/OccupationRepositoryIntegrationTest.php
@@ -11,10 +11,15 @@ declare(strict_types=1);
 
 namespace MagicSunday\Webtrees\Statistic\Test\Integration;
 
+use MagicSunday\Webtrees\Statistic\Normalization\NormalizedOccupation;
+use MagicSunday\Webtrees\Statistic\Normalization\OccupationFolding;
+use MagicSunday\Webtrees\Statistic\Normalization\RawOccupationNormalizer;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\StringList;
 use MagicSunday\Webtrees\Statistic\Repository\OccupationRepository;
 use MagicSunday\Webtrees\Statistic\Support\Aggregator\TopNAggregator;
 use MagicSunday\Webtrees\Statistic\Support\Database\TreeScope;
 use MagicSunday\Webtrees\Statistic\Support\Gedcom\GedcomScanner;
+use MagicSunday\Webtrees\Statistic\Test\Support\Normalization\StubOccupationNormalizer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -37,6 +42,11 @@ use function array_keys;
 #[UsesClass(TopNAggregator::class)]
 #[UsesClass(TreeScope::class)]
 #[UsesClass(GedcomScanner::class)]
+#[UsesClass(RawOccupationNormalizer::class)]
+#[UsesClass(NormalizedOccupation::class)]
+#[UsesClass(OccupationFolding::class)]
+#[UsesClass(StubOccupationNormalizer::class)]
+#[UsesClass(StringList::class)]
 final class OccupationRepositoryIntegrationTest extends AbstractIntegrationTestCase
 {
     /**
@@ -56,7 +66,7 @@ final class OccupationRepositoryIntegrationTest extends AbstractIntegrationTestC
     public function topOccupationsReturnsCaseFoldedFrequencies(): void
     {
         $tree   = $this->importFixtureTree('individual-facts.ged');
-        $result = (new OccupationRepository($tree))->top(10);
+        $result = (new OccupationRepository($tree, new RawOccupationNormalizer()))->top(10);
 
         self::assertSame(
             ['Blacksmith' => 3, 'Farmer' => 2, 'Carpenter' => 1, 'Teacher' => 1],
@@ -74,7 +84,7 @@ final class OccupationRepositoryIntegrationTest extends AbstractIntegrationTestC
     public function topOccupationsRespectsTheLimit(): void
     {
         $tree   = $this->importFixtureTree('individual-facts.ged');
-        $result = (new OccupationRepository($tree))->top(2);
+        $result = (new OccupationRepository($tree, new RawOccupationNormalizer()))->top(2);
 
         self::assertSame(['Blacksmith', 'Farmer'], array_keys($result));
     }
@@ -88,6 +98,55 @@ final class OccupationRepositoryIntegrationTest extends AbstractIntegrationTestC
     {
         $tree = $this->importFixtureTree('individual-facts.ged');
 
-        self::assertSame(4, (new OccupationRepository($tree))->countDistinct());
+        self::assertSame(4, (new OccupationRepository($tree, new RawOccupationNormalizer()))->countDistinct());
+    }
+
+    /**
+     * With a standardization provider the top-N counter folds on the provider's
+     * grouping key, not the raw spelling: a provider that maps both `Blacksmith`
+     * (three, incl. the case variant) and `Farmer` (two) onto one trade merges
+     * them into a single bucket of five under the provider display label, while
+     * the unmapped `Teacher` and `Carpenter` keep their raw case-fold. Contrast
+     * with {@see self::topOccupationsReturnsCaseFoldedFrequencies()}, which pins
+     * the four separate raw buckets — the merge is the provider's doing.
+     */
+    #[Test]
+    public function topOccupationsFoldOnTheProviderGroupingKey(): void
+    {
+        $tree = $this->importFixtureTree('individual-facts.ged');
+
+        $metal      = new NormalizedOccupation('de:Metall', 'Metall');
+        $normalizer = new StubOccupationNormalizer([
+            'Blacksmith' => $metal,
+            'blacksmith' => $metal,
+            'Farmer'     => $metal,
+        ]);
+
+        $result = (new OccupationRepository($tree, $normalizer))->top(10);
+
+        self::assertSame(
+            ['Metall' => 5, 'Carpenter' => 1, 'Teacher' => 1],
+            $result,
+        );
+        self::assertSame(1, $normalizer->batchCalls(), 'the whole distinct occupation set is resolved in one batch');
+    }
+
+    /**
+     * A purely numeric `1 OCCU` value (someone recording a code as the trade)
+     * must not crash the aggregation. The repository collects the distinct set
+     * as array keys, which coerces `1234` to an int; without the string
+     * round-trip in the fold the fallback `mb_strtolower()` would throw a
+     * TypeError under strict types and 500 the occupation chart. This exercises
+     * the real caller path (`array_keys(...)` → fold) that a `map()` unit test
+     * with a string literal cannot reproduce.
+     */
+    #[Test]
+    public function topOccupationsCountNumericValuesWithoutCoercionError(): void
+    {
+        $tree = $this->importFixtureTree('occupation-numeric.ged');
+
+        $result = (new OccupationRepository($tree, new RawOccupationNormalizer()))->top(10);
+
+        self::assertSame(['1234' => 1, 'Farmer' => 1], $result);
     }
 }

--- a/tests/Integration/TreeHealthPartnershipReachViewTest.php
+++ b/tests/Integration/TreeHealthPartnershipReachViewTest.php
@@ -14,6 +14,8 @@ namespace MagicSunday\Webtrees\Statistic\Test\Integration;
 use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\Tree;
 use Fisharebest\Webtrees\View;
+use MagicSunday\Webtrees\Statistic\Normalization\Contract\OccupationNormalizerInterface;
+use MagicSunday\Webtrees\Statistic\Normalization\RawOccupationNormalizer;
 use MagicSunday\Webtrees\Statistic\Statistic;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
@@ -177,6 +179,12 @@ final class TreeHealthPartnershipReachViewTest extends AbstractIntegrationTestCa
     private function renderTreeHealthTab(Tree $tree): string
     {
         Registry::container()->set(Tree::class, $tree);
+
+        // Mirror Module::boot(): the occupation normalizer is an interface with no
+        // autowirable implementation, so the container needs an explicit binding
+        // before it can build the Statistic facade. The identity default is the
+        // production behaviour on a site without a standardization provider.
+        Registry::container()->set(OccupationNormalizerInterface::class, new RawOccupationNormalizer());
 
         View::registerNamespace(
             self::MODULE,

--- a/tests/Support/Aggregator/TopNAggregatorTest.php
+++ b/tests/Support/Aggregator/TopNAggregatorTest.php
@@ -152,7 +152,7 @@ final class TopNAggregatorTest extends TestCase
     {
         self::assertSame([], TopNAggregator::rankKeys([], 0));
         self::assertSame([], TopNAggregator::rankKeys([], 5));
-        self::assertSame([], TopNAggregator::rank([], static fn (string $key): string => $key, 3));
+        self::assertSame([], TopNAggregator::rank([], static fn (int|string $key): string => (string) $key, 3));
     }
 
     /**
@@ -165,7 +165,7 @@ final class TopNAggregatorTest extends TestCase
     {
         $result = TopNAggregator::rank(
             ['zebra' => 2, 'mango' => 3, 'apple' => 2],
-            static fn (string $key): string => ucfirst($key),
+            static fn (int|string $key): string => ucfirst((string) $key),
             0,
         );
 
@@ -187,10 +187,36 @@ final class TopNAggregatorTest extends TestCase
 
         $result = TopNAggregator::rank(
             ['a' => 2, 'b' => 2],
-            static fn (string $key): string => $display[$key] ?? self::fail(sprintf('Expected a display label for key "%s"', $key)),
+            static fn (int|string $key): string => $display[$key] ?? self::fail(sprintf('Expected a display label for key "%s"', $key)),
             1,
         );
 
         self::assertSame(['Z' => 2], $result);
+    }
+
+    /**
+     * Two distinct fold keys that resolve to the SAME display label — the shape
+     * a normalization provider produces when two grouping keys render to one
+     * localized label — have their counts SUMMED into a single bucket that is
+     * then ranked by the COMBINED total. Here `k1` (3) and `k2` (3) both display
+     * as `Trade` (total 6), while the non-colliding `mid` (4) ranks between them
+     * on per-key count. The merged `Trade` bucket must overtake `mid` on its
+     * total of 6, landing first. A regression that summed but left the bucket at
+     * the first colliding key's rank position would order `mid` (4) ahead of
+     * `Trade` (6) — and a `top(1)` would then surface `mid`, hiding the true top
+     * trade; the ordered assertion below pins the total-based rank.
+     */
+    #[Test]
+    public function rankSumsCollidingLabelsAndRanksByTheCombinedTotal(): void
+    {
+        $display = ['k1' => 'Trade', 'k2' => 'Trade', 'mid' => 'Mid'];
+
+        $result = TopNAggregator::rank(
+            ['k1' => 3, 'k2' => 3, 'mid' => 4],
+            static fn (int|string $key): string => $display[$key] ?? self::fail(sprintf('Expected a display label for key "%s"', $key)),
+            0,
+        );
+
+        self::assertSame(['Trade' => 6, 'Mid' => 4], $result);
     }
 }

--- a/tests/Support/Normalization/StubOccupationNormalizer.php
+++ b/tests/Support/Normalization/StubOccupationNormalizer.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Test\Support\Normalization;
+
+use MagicSunday\Webtrees\Statistic\Normalization\Contract\OccupationNormalizerInterface;
+use MagicSunday\Webtrees\Statistic\Normalization\NormalizedOccupation;
+
+use function is_array;
+use function iterator_to_array;
+
+/**
+ * In-memory {@see OccupationNormalizerInterface} for tests. It resolves raw values from a
+ * caller-supplied lookup (keyed by the exact raw string) and counts how often
+ * the batch method runs, so a test can prove both the folding behaviour and the
+ * "provider is initialised once" contract without a real standardization
+ * module.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+final class StubOccupationNormalizer implements OccupationNormalizerInterface
+{
+    /**
+     * Number of {@see self::normalizeMany()} invocations, so a batch consumer
+     * can assert it resolves the whole set in one pass.
+     */
+    private int $batchCalls = 0;
+
+    /**
+     * @param array<string, NormalizedOccupation> $lookup Raw value => canned result; absent keys resolve to null
+     */
+    public function __construct(
+        private readonly array $lookup,
+    ) {
+    }
+
+    /**
+     * How often {@see self::normalizeMany()} has been called.
+     */
+    public function batchCalls(): int
+    {
+        return $this->batchCalls;
+    }
+
+    /**
+     * Resolve each input from the canned lookup, recording that a batch pass ran
+     * so the "provider is initialised once" contract can be asserted.
+     *
+     * @param iterable<string> $rawOccupations The distinct raw `1 OCCU` values to resolve
+     * @param string|null      $language       Ignored by the stub
+     *
+     * @return array<string, NormalizedOccupation|null> Keyed by each input; absent keys resolve to null
+     */
+    public function normalizeMany(iterable $rawOccupations, ?string $language = null): array
+    {
+        ++$this->batchCalls;
+
+        $values = is_array($rawOccupations) ? $rawOccupations : iterator_to_array($rawOccupations, false);
+
+        $result = [];
+
+        foreach ($values as $rawValue) {
+            $result[$rawValue] = $this->lookup[$rawValue] ?? null;
+        }
+
+        return $result;
+    }
+}

--- a/tests/Unit/Normalization/OccupationFoldingTest.php
+++ b/tests/Unit/Normalization/OccupationFoldingTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Test\Unit\Normalization;
+
+use MagicSunday\Webtrees\Statistic\Normalization\NormalizedOccupation;
+use MagicSunday\Webtrees\Statistic\Normalization\OccupationFolding;
+use MagicSunday\Webtrees\Statistic\Normalization\RawOccupationNormalizer;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\StringList;
+use MagicSunday\Webtrees\Statistic\Test\Support\Normalization\StubOccupationNormalizer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit coverage of {@see OccupationFolding::map()} — the batch fold that both
+ * occupation aggregations share. It proves the three behaviours that matter:
+ * variants of one trade collapse under a provider's grouping key, values the
+ * provider cannot place fall back to the pre-normalization case-fold, and the
+ * provider is consulted exactly once for the whole distinct set.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+#[CoversClass(OccupationFolding::class)]
+#[UsesClass(NormalizedOccupation::class)]
+#[UsesClass(RawOccupationNormalizer::class)]
+#[UsesClass(StubOccupationNormalizer::class)]
+#[UsesClass(StringList::class)]
+final class OccupationFoldingTest extends TestCase
+{
+    /**
+     * A provider that maps three spelling / gender / language variants of the
+     * same trade to one grouping key: every variant folds onto that key and
+     * shares the provider's display label, so the downstream aggregation counts
+     * them as a single bucket.
+     */
+    #[Test]
+    public function variantsCollapseUnderTheProviderGroupingKey(): void
+    {
+        $arzt = new NormalizedOccupation('de:Arzt', 'Arzt');
+
+        $normalizer = new StubOccupationNormalizer([
+            'Arzt'   => $arzt,
+            'ärztin' => $arzt,
+            'Doctor' => $arzt,
+        ]);
+
+        $folds = OccupationFolding::map(['Arzt', 'ärztin', 'Doctor'], $normalizer, 'de');
+
+        self::assertSame(
+            [
+                'Arzt'   => ['de:Arzt', 'Arzt'],
+                'ärztin' => ['de:Arzt', 'Arzt'],
+                'Doctor' => ['de:Arzt', 'Arzt'],
+            ],
+            $folds,
+        );
+    }
+
+    /**
+     * A value the provider cannot place keeps the pre-normalization fold: the
+     * key is the case-folded raw string and the label is the raw string
+     * unchanged, so no occupation is ever dropped.
+     */
+    #[Test]
+    public function unknownValuesFallBackToTheCaseFoldedRaw(): void
+    {
+        $normalizer = new StubOccupationNormalizer([
+            'Arzt' => new NormalizedOccupation('de:Arzt', 'Arzt'),
+        ]);
+
+        $folds = OccupationFolding::map(['Arzt', 'Schäfer'], $normalizer, 'de');
+
+        self::assertSame(
+            [
+                'Arzt'    => ['de:Arzt', 'Arzt'],
+                'Schäfer' => ['schäfer', 'Schäfer'],
+            ],
+            $folds,
+        );
+    }
+
+    /**
+     * The identity default resolves nothing, so every value folds exactly as it
+     * did before normalization existed: case-folded key, raw label.
+     */
+    #[Test]
+    public function rawNormalizerFoldsEveryValueByCaseAlone(): void
+    {
+        $folds = OccupationFolding::map(['Smith', 'smith', 'BAKER'], new RawOccupationNormalizer(), null);
+
+        self::assertSame(
+            [
+                'Smith' => ['smith', 'Smith'],
+                'smith' => ['smith', 'smith'],
+                'BAKER' => ['baker', 'BAKER'],
+            ],
+            $folds,
+        );
+    }
+
+    /**
+     * The whole distinct set is resolved in a single batch call, honouring the
+     * "a provider initialises its normalization data once" contract that the
+     * dashboard workflow relies on.
+     */
+    #[Test]
+    public function providerIsConsultedOnceForTheWholeSet(): void
+    {
+        $normalizer = new StubOccupationNormalizer([]);
+
+        OccupationFolding::map(['Arzt', 'Bäcker', 'Schmied'], $normalizer, 'de');
+
+        self::assertSame(1, $normalizer->batchCalls());
+    }
+}

--- a/tests/Unit/Normalization/RawOccupationNormalizerTest.php
+++ b/tests/Unit/Normalization/RawOccupationNormalizerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Test\Unit\Normalization;
+
+use MagicSunday\Webtrees\Statistic\Normalization\RawOccupationNormalizer;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\StringList;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit coverage of the identity {@see RawOccupationNormalizer}: it resolves
+ * nothing so every call site keeps the raw value, which is what makes wiring
+ * the seam a no-op for sites without a standardization provider.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+#[CoversClass(RawOccupationNormalizer::class)]
+#[UsesClass(StringList::class)]
+final class RawOccupationNormalizerTest extends TestCase
+{
+    /**
+     * The batch method returns one null per distinct input, keyed by the input
+     * string, so a consumer's fold map has an entry for every value.
+     */
+    #[Test]
+    public function normalizeManyReturnsANullKeyedByEachInput(): void
+    {
+        $result = (new RawOccupationNormalizer())->normalizeMany(['Arzt', 'Bäcker', 'Arzt'], 'de');
+
+        self::assertSame(['Arzt' => null, 'Bäcker' => null], $result);
+    }
+
+    /**
+     * A Traversable input is accepted just like an array, so callers can pass a
+     * lazily-built distinct set without materialising it first.
+     */
+    #[Test]
+    public function normalizeManyAcceptsATraversable(): void
+    {
+        $generator = (static function (): iterable {
+            yield 'Schmied';
+            yield 'Müller';
+        })();
+
+        $result = (new RawOccupationNormalizer())->normalizeMany($generator);
+
+        self::assertSame(['Schmied' => null, 'Müller' => null], $result);
+    }
+}

--- a/tests/Unit/Normalization/StandardizerModuleNormalizerTest.php
+++ b/tests/Unit/Normalization/StandardizerModuleNormalizerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Test\Unit\Normalization;
+
+use Fisharebest\Webtrees\Module\ModuleInterface;
+use Fisharebest\Webtrees\Services\ModuleService;
+use Illuminate\Support\Collection;
+use MagicSunday\Webtrees\Statistic\Normalization\StandardizerModuleNormalizer;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\StringList;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit coverage of the provider-absent behaviour of the standardizer adapter.
+ * Without an installed occupation-standardization module the adapter must
+ * resolve every value to null so the aggregations fall back to the raw string —
+ * the contract that makes wiring the adapter safe on sites that have no such
+ * module. The provider-present mapping cannot yet be represented as a unit
+ * fixture because the provider's classes only autoload when that optional module
+ * is installed; adding that automated coverage once its public API ships is
+ * tracked in issue #222, and until then it is verified manually against the live
+ * module.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+#[CoversClass(StandardizerModuleNormalizer::class)]
+#[UsesClass(StringList::class)]
+final class StandardizerModuleNormalizerTest extends TestCase
+{
+    /**
+     * With no module registered at all, every term resolves to null so the
+     * caller keeps the raw value.
+     */
+    #[Test]
+    public function normalizeManyReturnsAllNullWhenNoModuleIsInstalled(): void
+    {
+        $normalizer = new StandardizerModuleNormalizer($this->moduleServiceReturning([]));
+
+        self::assertSame(['Arzt' => null], $normalizer->normalizeMany(['Arzt'], 'de'));
+    }
+
+    /**
+     * A registered module that does not implement the provider interface is
+     * ignored, and the batch method returns one null per distinct input.
+     */
+    #[Test]
+    public function normalizeManyReturnsAllNullWhenNoProviderIsPresent(): void
+    {
+        $unrelatedModule = self::createStub(ModuleInterface::class);
+
+        $normalizer = new StandardizerModuleNormalizer($this->moduleServiceReturning([$unrelatedModule]));
+
+        self::assertSame(
+            ['Arzt' => null, 'Bäcker' => null],
+            $normalizer->normalizeMany(['Arzt', 'Bäcker'], 'de'),
+        );
+    }
+
+    /**
+     * Build a ModuleService test double whose module registry is the given list.
+     *
+     * @param list<ModuleInterface> $modules
+     */
+    private function moduleServiceReturning(array $modules): ModuleService
+    {
+        $moduleService = self::createStub(ModuleService::class);
+        $moduleService->method('all')->willReturn(new Collection($modules));
+
+        return $moduleService;
+    }
+}

--- a/tests/fixtures/occupation-inheritance-language-variants.ged
+++ b/tests/fixtures/occupation-inheritance-language-variants.ged
@@ -1,0 +1,38 @@
+0 HEAD
+1 SOUR webtrees-statistics-fixture
+2 NAME occupation-inheritance-language-variants
+1 DEST ANSTFILE
+1 CHAR UTF-8
+1 SUBM @SUBM1@
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+0 @SUBM1@ SUBM
+1 NAME Fixture
+0 @I1@ INDI
+1 NAME Vater /Arzt/
+1 SEX M
+1 OCCU Arzt
+1 FAMS @F1@
+0 @I2@ INDI
+1 NAME Sohn /Arzt/
+1 SEX M
+1 OCCU Arzt
+1 FAMC @F1@
+0 @I3@ INDI
+1 NAME Vater /Doctor/
+1 SEX M
+1 OCCU Doctor
+1 FAMS @F2@
+0 @I4@ INDI
+1 NAME Sohn /Doctor/
+1 SEX M
+1 OCCU Doctor
+1 FAMC @F2@
+0 @F1@ FAM
+1 HUSB @I1@
+1 CHIL @I2@
+0 @F2@ FAM
+1 HUSB @I3@
+1 CHIL @I4@
+0 TRLR

--- a/tests/fixtures/occupation-numeric.ged
+++ b/tests/fixtures/occupation-numeric.ged
@@ -1,0 +1,20 @@
+0 HEAD
+1 SOUR webtrees-statistics-fixture
+2 NAME occupation-numeric
+1 DEST ANSTFILE
+1 CHAR UTF-8
+1 SUBM @SUBM1@
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+0 @SUBM1@ SUBM
+1 NAME Fixture
+0 @I1@ INDI
+1 NAME Erster /Muster/
+1 SEX M
+1 OCCU 1234
+0 @I2@ INDI
+1 NAME Zweiter /Muster/
+1 SEX M
+1 OCCU Farmer
+0 TRLR


### PR DESCRIPTION
Closes #220.

## Motivation

The occupation aggregations — the top-N occupations card and the parent → child occupation-inheritance Sankey — fold on the raw `1 OCCU` string. Spelling and language variants of the *same* trade therefore fragment into separate bars and flows. A hand-curated synonym list would fix this for only one language and one user's data, so this module instead becomes a *consumer* of whatever occupation standardization a site has available and degrades gracefully to the raw value when none is present.

## Design

A narrow `OccupationNormalizerInterface` seam the aggregations resolve their trades through:

- `NormalizedOccupation` — value object carrying a stable grouping key + a display label (plus optional HISCO code / HISCAM score a provider may expose).
- `RawOccupationNormalizer` — identity default returning null for everything, so without a provider both aggregations stay byte-identical to their pre-normalization behaviour.
- `OccupationFolding::map()` — batch helper that resolves the whole distinct-trade set of a tree in one call (so a provider initialises its data once) and folds every value to `[fold key, display label]`, falling back to the case-folded raw for anything the provider cannot place.
- `StandardizerModuleNormalizer` — adapter that resolves an installed occupation-standardization module in-process via `ModuleService` (matched by its published interface, name-independent) and maps its result onto `NormalizedOccupation`. Bound in `Module::boot()`, so **installing such a module is the opt-in** — sites without one are unaffected.

Both occupation repositories are wired behind the seam. `TopNAggregator::topN()` gains an optional fold resolver, leaving the religion / cause-of-death counters (and the name / country aggregations that share `rank()`/`rankKeys()`) byte-identical; `rank()` now folds two grouping keys that render to one localized label into a single bucket ranked by their combined total.

The optional provider's public API is declared to static analysis via a PHPStan `scanFiles` stub (analysis-only, never loaded at runtime); the `Normalization` layer is pinned by dedicated architecture rules.

## Testing

Full unit + integration coverage: the identity default, the batch fold + case-fold fallback, the "resolved once per tree" contract, a provider stub proving variant-merging in both cards, the label-collision ranking, and a numeric-`1 OCCU` regression (a value like `1234` becomes an int array key — exercised through the real repository path). The provider-*present* field mapping is verified manually against the live module and tracked for automated coverage in #222 (the provider's public API is not yet published to a resolvable release).

Verified live against a real tree with the standardization module both absent (no regression) and installed (the adapter resolves it and the charts render, unknown trades falling back to raw).