### PR TITLE
GH-224: Resolve the occupation content-language hint from the site preference

### DIFF
--- a/src/Normalization/Support/ContentLanguage.php
+++ b/src/Normalization/Support/ContentLanguage.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Normalization\Support;
+
+use Fisharebest\Webtrees\Site;
+
+/**
+ * Resolves the content-language hint handed to an occupation-standardization
+ * provider so it can pick the matching language rules. webtrees has no per-tree
+ * language *preference* — core moved `LANGUAGE` from a per-tree `gedcom_setting`
+ * to a SITE-level `site_setting` (Migration 43), so it is now only configurable
+ * under Control panel → Website preferences → Default language. That admin-set
+ * default is the stable, viewer-independent proxy for the language the
+ * occupation strings are written in; the current front-end language is
+ * deliberately NOT used, because it is per-viewer and would fold the same tree
+ * differently for every observer (an English viewer of a German tree would
+ * suppress the German matches).
+ *
+ * Deliberate limitation: the GEDCOM header `HEAD.LANG` is a per-tree
+ * content-language signal, but it is frequently absent and deprecated in
+ * GEDCOM 7, so it is not consulted — a single site default is used for every
+ * tree. On a multi-tree install whose trees hold different content languages
+ * this hands the "wrong" language to the provider for the non-default trees;
+ * that is harmless under the identity default (the hint is inert) and only
+ * shifts grouping when a language-gated provider is installed, which is an
+ * accepted trade-off for a single-language install.
+ *
+ * The returned value is a full webtrees locale tag and may carry a region
+ * subtag (`en-US`, `pt-BR`); a consumer that keys on a bare language subtag must
+ * take the primary subtag itself. An empty preference resolves to null so a
+ * provider that gates recognition on a concrete language receives "no hint"
+ * uniformly rather than an empty string (in practice the site default is
+ * `en-US`, so this only fires when an admin explicitly blanks the value).
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+final readonly class ContentLanguage
+{
+    /**
+     * Prevent instantiation — static-only utility.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * The site's configured default language as a BCP-47 tag, or null when no
+     * language is configured.
+     */
+    public static function tag(): ?string
+    {
+        $language = Site::getPreference('LANGUAGE');
+
+        return $language !== '' ? $language : null;
+    }
+}

--- a/src/Repository/OccupationInheritanceRepository.php
+++ b/src/Repository/OccupationInheritanceRepository.php
@@ -22,6 +22,7 @@ use MagicSunday\Webtrees\Statistic\Model\Sankey\SankeyFlowsPayload;
 use MagicSunday\Webtrees\Statistic\Model\Sankey\SankeySample;
 use MagicSunday\Webtrees\Statistic\Normalization\Contract\OccupationNormalizerInterface;
 use MagicSunday\Webtrees\Statistic\Normalization\OccupationFolding;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\ContentLanguage;
 use MagicSunday\Webtrees\Statistic\Support\Database\TreeScope;
 use MagicSunday\Webtrees\Statistic\Support\Gedcom\GedcomScanner;
 use MagicSunday\Webtrees\Statistic\Support\Gedcom\RowCast;
@@ -191,7 +192,7 @@ final readonly class OccupationInheritanceRepository
         // raw value maps to its (fold key, display label); unknown values keep
         // the pre-normalization case-fold, so the identity default leaves the
         // aggregation byte-identical.
-        $folds = OccupationFolding::map(array_keys($distinctRaw), $this->normalizer, TreeScope::languageTag($this->tree));
+        $folds = OccupationFolding::map(array_keys($distinctRaw), $this->normalizer, ContentLanguage::tag());
 
         // Fold every person's raw values to their DISTINCT trades under the
         // resolved keys.

--- a/src/Repository/OccupationRepository.php
+++ b/src/Repository/OccupationRepository.php
@@ -16,7 +16,7 @@ use Fisharebest\Webtrees\Tree;
 use Illuminate\Support\Collection;
 use MagicSunday\Webtrees\Statistic\Normalization\Contract\OccupationNormalizerInterface;
 use MagicSunday\Webtrees\Statistic\Normalization\OccupationFolding;
-use MagicSunday\Webtrees\Statistic\Support\Database\TreeScope;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\ContentLanguage;
 use MagicSunday\Webtrees\Statistic\Support\Gedcom\GedcomScanner;
 
 use function array_keys;
@@ -87,7 +87,7 @@ final class OccupationRepository extends AbstractGedcomTagTopNRepository
             }
         }
 
-        $folds = OccupationFolding::map(array_keys($distinctRaw), $this->normalizer, TreeScope::languageTag($this->tree()));
+        $folds = OccupationFolding::map(array_keys($distinctRaw), $this->normalizer, ContentLanguage::tag());
 
         return static fn (string $value): array => $folds[$value] ?? [mb_strtolower($value), $value];
     }

--- a/src/Support/Database/TreeScope.php
+++ b/src/Support/Database/TreeScope.php
@@ -104,17 +104,4 @@ final readonly class TreeScope
             ->select(['i_gedcom AS gedcom'])
             ->get();
     }
-
-    /**
-     * The tree's configured language as a BCP-47 tag for consumers that need a
-     * language hint (e.g. occupation normalization), or null when the tree has
-     * no language preference set. An empty preference is normalised to null so
-     * callers can treat "unset" uniformly.
-     */
-    public static function languageTag(Tree $tree): ?string
-    {
-        $language = $tree->getPreference('LANGUAGE');
-
-        return $language !== '' ? $language : null;
-    }
 }

--- a/tests/Integration/ContentLanguageTest.php
+++ b/tests/Integration/ContentLanguageTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Statistic\Test\Integration;
+
+use Fisharebest\Webtrees\Site;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\ContentLanguage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Verifies that the occupation content-language hint is resolved from the
+ * SITE-level `LANGUAGE` preference — the only language webtrees actually
+ * configures (there is no per-tree language). An empty preference resolves to
+ * null so a provider that gates on a concrete language is simply not steered.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-statistics/
+ */
+#[CoversClass(ContentLanguage::class)]
+final class ContentLanguageTest extends AbstractIntegrationTestCase
+{
+    /**
+     * The configured site default language becomes the content-language hint.
+     */
+    #[Test]
+    public function tagReturnsTheConfiguredSiteLanguage(): void
+    {
+        $previous = Site::getPreference('LANGUAGE');
+
+        try {
+            Site::setPreference('LANGUAGE', 'de');
+
+            self::assertSame('de', ContentLanguage::tag());
+        } finally {
+            Site::setPreference('LANGUAGE', $previous);
+        }
+    }
+
+    /**
+     * An unset (empty) site language resolves to null rather than an empty
+     * string, so a language-gated provider receives "no hint" uniformly.
+     */
+    #[Test]
+    public function tagReturnsNullWhenTheSiteLanguageIsEmpty(): void
+    {
+        $previous = Site::getPreference('LANGUAGE');
+
+        try {
+            Site::setPreference('LANGUAGE', '');
+
+            self::assertNull(ContentLanguage::tag());
+        } finally {
+            Site::setPreference('LANGUAGE', $previous);
+        }
+    }
+}

--- a/tests/Integration/OccupationInheritanceRepositoryIntegrationTest.php
+++ b/tests/Integration/OccupationInheritanceRepositoryIntegrationTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\Webtrees\Statistic\Test\Integration;
 
 use Fisharebest\Webtrees\Auth;
+use Fisharebest\Webtrees\Site;
 use Fisharebest\Webtrees\Tree;
 use MagicSunday\Webtrees\Statistic\Model\Sankey\SankeyFlowsPayload;
 use MagicSunday\Webtrees\Statistic\Model\Sankey\SankeyLink;
@@ -19,6 +20,7 @@ use MagicSunday\Webtrees\Statistic\Model\Sankey\SankeySample;
 use MagicSunday\Webtrees\Statistic\Normalization\NormalizedOccupation;
 use MagicSunday\Webtrees\Statistic\Normalization\OccupationFolding;
 use MagicSunday\Webtrees\Statistic\Normalization\RawOccupationNormalizer;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\ContentLanguage;
 use MagicSunday\Webtrees\Statistic\Normalization\Support\StringList;
 use MagicSunday\Webtrees\Statistic\Repository\OccupationInheritanceRepository;
 use MagicSunday\Webtrees\Statistic\Repository\ParentMapRepository;
@@ -72,6 +74,7 @@ use function array_unique;
 #[UsesClass(OccupationFolding::class)]
 #[UsesClass(StubOccupationNormalizer::class)]
 #[UsesClass(StringList::class)]
+#[UsesClass(ContentLanguage::class)]
 final class OccupationInheritanceRepositoryIntegrationTest extends AbstractIntegrationTestCase
 {
     /**
@@ -172,6 +175,33 @@ final class OccupationInheritanceRepositoryIntegrationTest extends AbstractInteg
         self::assertSame(['Arzt', 'Arzt'], $result->nodes, 'the merged flow shows the provider display label');
         self::assertSame(2, $result->links[0]->value, 'the merged flow carries the combined weight');
         self::assertSame(1, $normalizer->batchCalls(), 'the whole distinct trade set is resolved in one batch');
+    }
+
+    /**
+     * The content-language hint forwarded to the normalizer is the SITE default
+     * language (webtrees has no per-tree language). Regression guard for the
+     * bug where the hint was read from an unset per-tree `LANGUAGE` preference
+     * and therefore always arrived as null — leaving a language-gated provider
+     * unable to recognise anything.
+     */
+    #[Test]
+    public function occupationNormalizerReceivesTheSiteContentLanguage(): void
+    {
+        $previous = Site::getPreference('LANGUAGE');
+
+        try {
+            Site::setPreference('LANGUAGE', 'de');
+
+            $tree       = $this->importFixtureTree('occupation-inheritance-language-variants.ged');
+            $normalizer = new StubOccupationNormalizer([]);
+
+            (new OccupationInheritanceRepository($tree, new ParentMapRepository($tree), $normalizer))
+                ->occupationInheritance(10, 1);
+
+            self::assertSame('de', $normalizer->lastLanguage(), 'the site content language is forwarded to the provider');
+        } finally {
+            Site::setPreference('LANGUAGE', $previous);
+        }
     }
 
     /**

--- a/tests/Integration/OccupationRepositoryIntegrationTest.php
+++ b/tests/Integration/OccupationRepositoryIntegrationTest.php
@@ -11,9 +11,11 @@ declare(strict_types=1);
 
 namespace MagicSunday\Webtrees\Statistic\Test\Integration;
 
+use Fisharebest\Webtrees\Site;
 use MagicSunday\Webtrees\Statistic\Normalization\NormalizedOccupation;
 use MagicSunday\Webtrees\Statistic\Normalization\OccupationFolding;
 use MagicSunday\Webtrees\Statistic\Normalization\RawOccupationNormalizer;
+use MagicSunday\Webtrees\Statistic\Normalization\Support\ContentLanguage;
 use MagicSunday\Webtrees\Statistic\Normalization\Support\StringList;
 use MagicSunday\Webtrees\Statistic\Repository\OccupationRepository;
 use MagicSunday\Webtrees\Statistic\Support\Aggregator\TopNAggregator;
@@ -47,6 +49,7 @@ use function array_keys;
 #[UsesClass(OccupationFolding::class)]
 #[UsesClass(StubOccupationNormalizer::class)]
 #[UsesClass(StringList::class)]
+#[UsesClass(ContentLanguage::class)]
 final class OccupationRepositoryIntegrationTest extends AbstractIntegrationTestCase
 {
     /**
@@ -148,5 +151,31 @@ final class OccupationRepositoryIntegrationTest extends AbstractIntegrationTestC
         $result = (new OccupationRepository($tree, new RawOccupationNormalizer()))->top(10);
 
         self::assertSame(['1234' => 1, 'Farmer' => 1], $result);
+    }
+
+    /**
+     * The Top-N occupations card is the SECOND consumer of the site-language
+     * fix, so it gets its own propagation guard mirroring the inheritance card:
+     * with Site `LANGUAGE='de'` the normalizer must receive `'de'`. Without this
+     * the `OccupationRepository` call site could silently revert to forwarding
+     * null and no test would fail.
+     */
+    #[Test]
+    public function occupationNormalizerReceivesTheSiteContentLanguage(): void
+    {
+        $previous = Site::getPreference('LANGUAGE');
+
+        try {
+            Site::setPreference('LANGUAGE', 'de');
+
+            $tree       = $this->importFixtureTree('individual-facts.ged');
+            $normalizer = new StubOccupationNormalizer([]);
+
+            (new OccupationRepository($tree, $normalizer))->top(10);
+
+            self::assertSame('de', $normalizer->lastLanguage(), 'the site content language is forwarded to the provider');
+        } finally {
+            Site::setPreference('LANGUAGE', $previous);
+        }
     }
 }

--- a/tests/Support/Normalization/StubOccupationNormalizer.php
+++ b/tests/Support/Normalization/StubOccupationNormalizer.php
@@ -37,6 +37,12 @@ final class StubOccupationNormalizer implements OccupationNormalizerInterface
     private int $batchCalls = 0;
 
     /**
+     * The language hint passed on the most recent {@see self::normalizeMany()}
+     * call, so a test can assert which content language a consumer forwards.
+     */
+    private ?string $lastLanguage = null;
+
+    /**
      * @param array<string, NormalizedOccupation> $lookup Raw value => canned result; absent keys resolve to null
      */
     public function __construct(
@@ -53,17 +59,27 @@ final class StubOccupationNormalizer implements OccupationNormalizerInterface
     }
 
     /**
+     * The language hint received on the most recent {@see self::normalizeMany()}
+     * call, or null when none was supplied.
+     */
+    public function lastLanguage(): ?string
+    {
+        return $this->lastLanguage;
+    }
+
+    /**
      * Resolve each input from the canned lookup, recording that a batch pass ran
      * so the "provider is initialised once" contract can be asserted.
      *
      * @param iterable<string> $rawOccupations The distinct raw `1 OCCU` values to resolve
-     * @param string|null      $language       Ignored by the stub
+     * @param string|null      $language       Recorded for {@see self::lastLanguage()}; does not affect the lookup
      *
      * @return array<string, NormalizedOccupation|null> Keyed by each input; absent keys resolve to null
      */
     public function normalizeMany(iterable $rawOccupations, ?string $language = null): array
     {
         ++$this->batchCalls;
+        $this->lastLanguage = $language;
 
         $values = is_array($rawOccupations) ? $rawOccupations : iterator_to_array($rawOccupations, false);
 

--- a/tests/View/MarriageExtremesViewTest.php
+++ b/tests/View/MarriageExtremesViewTest.php
@@ -151,6 +151,8 @@ final class MarriageExtremesViewTest extends TestCase
             include $partial;
         })(__DIR__ . '/../../resources/views/modules/statistics-chart/components/marriage-extremes.phtml', $data);
 
-        return ob_get_clean();
+        $html = ob_get_clean();
+
+        return $html !== false ? $html : '';
     }
 }


### PR DESCRIPTION
Fixes #224.

## Problem
The occupation-normalization seam forwards a content-language hint to a standardization provider so it can pick the matching language rules. The hint was resolved via `TreeScope::languageTag(Tree)` reading `$tree->getPreference('LANGUAGE')`.

But webtrees has no per-tree `LANGUAGE` preference: core Migration 43 moved `LANGUAGE` from a per-tree `gedcom_setting` to a **site-level** `site_setting` (Control panel → Website preferences → Default language). So the per-tree read always returned `''` → `null`, the provider never received a language, and a language-gated provider recognised nothing regardless of the configured site language — the seam was silently a no-op.

## Fix
- New `Normalization\Support\ContentLanguage::tag()` resolves the hint from `Site::getPreference('LANGUAGE')` (empty → `null`). The current front-end language is deliberately **not** used: it is per-viewer and would fold a tree differently for every observer (an English viewer of a German tree would suppress the German matches).
- `TreeScope::languageTag()` removed (a site-level value has no place on a tree-scoped query builder); both occupation repositories now call `ContentLanguage::tag()`.
- The docblock documents the accepted trade-offs (the deprecated/often-absent GEDCOM `HEAD.LANG` is not consulted; the value may carry a region subtag).

## Tests
- `ContentLanguageTest` — resolves the site language, and `null` when blanked.
- A propagation regression guard on **each** of the two consumer call sites (Top-N occupations and parent → child inheritance), so reverting either to a null hint reds a test. `StubOccupationNormalizer` gained a `lastLanguage()` recorder.

Full PHP CI green (PHPStan max, CGL, Rector, lint, 829 tests).