### PR TITLE
GH-222: Cover the occupation-standardizer adapter's provider-present mapping

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,4 +23,5 @@
 /resources/js/modules/ export-ignore
 /resources/js/tests/   export-ignore
 /rollup.config.js      export-ignore
+/stubs/                export-ignore
 /tests/                export-ignore

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,7 @@
          xsi:noNamespaceSchemaLocation="./.build/vendor/phpunit/phpunit/phpunit.xsd"
          beStrictAboutCoverageMetadata="true"
          beStrictAboutOutputDuringTests="true"
-         bootstrap="./.build/vendor/autoload.php"
+         bootstrap="./tests/bootstrap.php"
          cacheDirectory="./.build/cache/.phpunit.cache"
          colors="true"
          displayDetailsOnPhpunitDeprecations="true"

--- a/stubs/hh_occupation_standardizer.stub
+++ b/stubs/hh_occupation_standardizer.stub
@@ -1,55 +1,134 @@
 <?php
 
 /**
- * PHPStan stub for the optional occupation-standardization provider
- * (hartenthaler/hh_occupation_standardizer). The module is an optional runtime
- * dependency resolved in-process via ModuleService; it is never required by this
- * package, so its public-API classes are not on this package's autoload path.
- * This stub declares exactly the public surface {@see StandardizerModuleNormalizer}
- * consumes, so static analysis can type-check the adapter without the provider
- * being installed. It mirrors the provider's published contract in
- * docs/public-api.md.
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
  */
 
 declare(strict_types=1);
 
 namespace Hartenthaler\Webtrees\Module\OccupationStandardizer\PublicApi;
 
+/*
+ * Faithful stand-in for the optional occupation-standardization provider
+ * (hartenthaler/hh_occupation_standardizer). The module is an optional runtime
+ * dependency resolved in-process via ModuleService; it is never required by this
+ * package, so its public-API classes are not on this package's autoload path.
+ *
+ * This stub mirrors the provider's published public-API surface from
+ * docs/public-api.md — the surface this package's StandardizerModuleNormalizer
+ * adapter consumes a subset of. It serves two callers from one source of truth:
+ * static analysis discovers it via phpstan's `scanFiles`, and the adapter's unit
+ * test loads it through the PHPUnit bootstrap to exercise the provider-present
+ * mapping without installing the provider. The methods therefore carry real,
+ * side-effect-free bodies; the constructor is a test-support convenience — the
+ * provider never exposes it to this package, which only ever reads the accessors
+ * below.
+ */
+
+/**
+ * Read-only contract a webtrees module publishes to let other modules
+ * standardize raw occupation strings without depending on it directly.
+ */
 interface OccupationStandardizerInterface
 {
+    /**
+     * Standardize a single raw occupation string.
+     *
+     * @param string      $raw_occupation The raw `1 OCCU` value to standardize
+     * @param string|null $language       BCP-47 language the value is written in, or null when unknown
+     *
+     * @return StandardizedOccupation|null The standardized result, or null when unrecognized
+     */
     public function standardize(string $raw_occupation, ?string $language = null): ?StandardizedOccupation;
 
     /**
-     * @param iterable<string> $raw_occupations
+     * Standardize a batch of raw occupation strings in one call.
      *
-     * @return array<string, StandardizedOccupation|null>
+     * @param iterable<string> $raw_occupations The distinct raw `1 OCCU` values to standardize
+     * @param string|null      $language        BCP-47 language every value is written in, or null when unknown
+     *
+     * @return array<string, StandardizedOccupation|null> Keyed by each input string; null when unrecognized
      */
     public function standardizeMany(iterable $raw_occupations, ?string $language = null): array;
 }
 
-final class StandardizedOccupation
+/**
+ * Immutable result of standardizing one raw occupation string.
+ */
+final readonly class StandardizedOccupation
 {
+    /**
+     * @param string                $canonicalKey     Language-independent grouping key under which every variant of this trade folds
+     * @param string                $canonicalLabel   Fallback label used when no per-language label matches
+     * @param array<string, string> $labelsByLanguage Display label per BCP-47 language tag; the empty-string key is the fallback used when the tree language is unknown
+     * @param string|null           $hiscoCode        Optional HISCO classification code, or null when unavailable
+     * @param string|null           $hisclass         Optional HISCLASS code, or null when unavailable
+     * @param float|null            $hiscamScore      Optional HISCAM social-status score, or null when unavailable
+     */
+    public function __construct(
+        private string $canonicalKey = '',
+        private string $canonicalLabel = '',
+        private array $labelsByLanguage = [],
+        private ?string $hiscoCode = null,
+        private ?string $hisclass = null,
+        private ?float $hiscamScore = null,
+    ) {
+    }
+
+    /**
+     * @return string The fallback label used when no per-language label matches
+     */
     public function canonicalLabel(): string
     {
+        return $this->canonicalLabel;
     }
 
+    /**
+     * @return string The language-independent grouping key under which every variant of this trade folds
+     */
     public function canonicalKey(): string
     {
+        return $this->canonicalKey;
     }
 
+    /**
+     * Resolve the readable label for the given language, falling back to the
+     * canonical label when no per-language label matches.
+     *
+     * @param string      $language The BCP-47 language to resolve the label for; the empty string requests the language-neutral fallback
+     * @param string|null $sex      Optional sex to resolve a gendered label for, or null for the neutral form
+     *
+     * @return string The resolved display label
+     */
     public function displayLabel(string $language, ?string $sex = null): string
     {
+        return $this->labelsByLanguage[$language] ?? $this->canonicalLabel;
     }
 
+    /**
+     * @return string|null The HISCO classification code, or null when unavailable
+     */
     public function hiscoCode(): ?string
     {
+        return $this->hiscoCode;
     }
 
+    /**
+     * @return string|null The HISCLASS code, or null when unavailable
+     */
     public function hisclass(): ?string
     {
+        return $this->hisclass;
     }
 
+    /**
+     * @return float|null The HISCAM social-status score, or null when unavailable
+     */
     public function hiscamScore(): ?float
     {
+        return $this->hiscamScore;
     }
 }

--- a/tests/Unit/Normalization/StandardizerModuleNormalizerTest.php
+++ b/tests/Unit/Normalization/StandardizerModuleNormalizerTest.php
@@ -13,7 +13,10 @@ namespace MagicSunday\Webtrees\Statistic\Test\Unit\Normalization;
 
 use Fisharebest\Webtrees\Module\ModuleInterface;
 use Fisharebest\Webtrees\Services\ModuleService;
+use Hartenthaler\Webtrees\Module\OccupationStandardizer\PublicApi\OccupationStandardizerInterface;
+use Hartenthaler\Webtrees\Module\OccupationStandardizer\PublicApi\StandardizedOccupation;
 use Illuminate\Support\Collection;
+use MagicSunday\Webtrees\Statistic\Normalization\NormalizedOccupation;
 use MagicSunday\Webtrees\Statistic\Normalization\StandardizerModuleNormalizer;
 use MagicSunday\Webtrees\Statistic\Normalization\Support\StringList;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -22,15 +25,19 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Unit coverage of the provider-absent behaviour of the standardizer adapter.
- * Without an installed occupation-standardization module the adapter must
- * resolve every value to null so the aggregations fall back to the raw string —
- * the contract that makes wiring the adapter safe on sites that have no such
- * module. The provider-present mapping cannot yet be represented as a unit
- * fixture because the provider's classes only autoload when that optional module
- * is installed; adding that automated coverage once its public API ships is
- * tracked in issue #222, and until then it is verified manually against the live
- * module.
+ * Unit coverage of the standardizer adapter's two paths. Without an installed
+ * occupation-standardization module the adapter must resolve every value to null
+ * so the aggregations fall back to the raw string — the contract that makes
+ * wiring the adapter safe on sites that have no such module. With a provider
+ * present it must map each recognized {@see StandardizedOccupation} field onto
+ * this module's {@see NormalizedOccupation} and keep the raw value for every
+ * unrecognized entry.
+ *
+ * The provider's public-API classes only autoload when that optional module is
+ * installed, so the provider-present tests run against the faithful stand-in in
+ * `stubs/hh_occupation_standardizer.stub` — the same stub static analysis scans,
+ * loaded for the test run via the PHPUnit bootstrap. This keeps the seam free of
+ * a hard dependency on the provider while still exercising the mapping.
  *
  * @author  Rico Sonntag <mail@ricosonntag.de>
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
@@ -38,6 +45,7 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversClass(StandardizerModuleNormalizer::class)]
 #[UsesClass(StringList::class)]
+#[UsesClass(NormalizedOccupation::class)]
 final class StandardizerModuleNormalizerTest extends TestCase
 {
     /**
@@ -67,6 +75,86 @@ final class StandardizerModuleNormalizerTest extends TestCase
             ['Arzt' => null, 'Bäcker' => null],
             $normalizer->normalizeMany(['Arzt', 'Bäcker'], 'de'),
         );
+    }
+
+    /**
+     * A recognized result maps every provider field onto the value object, while
+     * an unrecognized entry in the same batch keeps its null so the caller falls
+     * back to the raw value.
+     */
+    #[Test]
+    public function normalizeManyMapsEveryProviderFieldOntoTheValueObject(): void
+    {
+        $standardized = new StandardizedOccupation(
+            canonicalKey: 'de:baecker',
+            canonicalLabel: 'Bäcker',
+            labelsByLanguage: ['de' => 'Bäcker'],
+            hiscoCode: '75430',
+            hisclass: '7',
+            hiscamScore: 45.6,
+        );
+
+        $normalizer = new StandardizerModuleNormalizer(
+            $this->moduleServiceWithProviderReturning(['Bäcker' => $standardized, 'Unbekannt' => null]),
+        );
+
+        $result = $normalizer->normalizeMany(['Bäcker', 'Unbekannt'], 'de');
+
+        self::assertArrayHasKey('Unbekannt', $result);
+        self::assertNull($result['Unbekannt']);
+
+        self::assertArrayHasKey('Bäcker', $result);
+        $mapped = $result['Bäcker'];
+        self::assertInstanceOf(NormalizedOccupation::class, $mapped);
+        self::assertSame('de:baecker', $mapped->groupingKey);
+        self::assertSame('Bäcker', $mapped->displayLabel);
+        self::assertSame('75430', $mapped->hiscoCode);
+        self::assertSame(45.6, $mapped->hiscamScore);
+    }
+
+    /**
+     * When the tree language is unknown the adapter resolves the display label
+     * with the empty-string language, exercising the language-default branch.
+     */
+    #[Test]
+    public function normalizeManyResolvesTheDisplayLabelWithEmptyLanguageWhenLanguageIsNull(): void
+    {
+        $standardized = new StandardizedOccupation(
+            canonicalKey: 'de:baecker',
+            canonicalLabel: 'Bäcker',
+            labelsByLanguage: ['de' => 'Bäcker (de)', '' => 'Bäcker (neutral)'],
+        );
+
+        $normalizer = new StandardizerModuleNormalizer(
+            $this->moduleServiceWithProviderReturning(['Bäcker' => $standardized]),
+        );
+
+        // No language argument leaves it at its null default — the unknown-language
+        // case the adapter resolves through the empty-string display label.
+        $result = $normalizer->normalizeMany(['Bäcker']);
+
+        self::assertArrayHasKey('Bäcker', $result);
+        $mapped = $result['Bäcker'];
+        self::assertInstanceOf(NormalizedOccupation::class, $mapped);
+        self::assertSame('Bäcker (neutral)', $mapped->displayLabel);
+        self::assertNull($mapped->hiscoCode);
+        self::assertNull($mapped->hiscamScore);
+    }
+
+    /**
+     * Build a ModuleService whose single registered module is a provider stub
+     * returning the given raw-value → result map from its batch method.
+     *
+     * @param array<string, StandardizedOccupation|null> $results
+     */
+    private function moduleServiceWithProviderReturning(array $results): ModuleService
+    {
+        $provider = self::createStubForIntersectionOfInterfaces(
+            [ModuleInterface::class, OccupationStandardizerInterface::class],
+        );
+        $provider->method('standardizeMany')->willReturn($results);
+
+        return $this->moduleServiceReturning([$provider]);
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-statistics.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * PHPUnit bootstrap.
+ *
+ * Loads the composer autoloader, then the faithful stand-in for the optional
+ * occupation-standardization provider's public API. The provider module is never
+ * a dependency of this package, so its classes are not autoloadable; loading the
+ * stub here lets the standardizer adapter's provider-present mapping be exercised
+ * as a unit test. Static analysis discovers the same stub via phpstan's
+ * `scanFiles`, keeping one source of truth for the provider contract.
+ */
+
+require_once __DIR__ . '/../.build/vendor/autoload.php';
+require_once __DIR__ . '/../stubs/hh_occupation_standardizer.stub';


### PR DESCRIPTION
## Summary

Adds automated coverage for the occupation-standardizer adapter's provider-present mapping path (closes #222).

`StandardizerModuleNormalizer` resolves an optional occupation-standardization provider module through webtrees' `ModuleService` and maps its `StandardizedOccupation` onto this package's `NormalizedOccupation`. Only the provider-**absent** path was unit-tested; the **present** mapping was verified manually, because the provider's public-API classes autoload only when that optional module is installed.

## Approach

The issue originally proposed pulling the provider in as a `require-dev` dependency. That would couple this package to the provider and undercut the optional-provider seam. Instead this turns the existing PHPStan `scanFiles` stub (`stubs/hh_occupation_standardizer.stub`) into a **faithful, runtime-loadable stand-in** of the provider's published public API — one source of truth for both static analysis and the unit test — loaded through a new PHPUnit bootstrap (`tests/bootstrap.php`).

## Coverage added

- Every mapped field: `canonicalKey → groupingKey`, `displayLabel(language ?? '') → displayLabel`, `hiscoCode`, `hiscamScore`.
- The unknown-language branch (`language === null → displayLabel('')`).
- The unrecognized-entry passthrough (provider returns `null` for a value → the adapter keeps the raw value).

## Notes

- `stubs/` is now `export-ignore`d — a dev/static-analysis/test-only artifact never loaded at runtime.
- No `src`/production change; the adapter itself is unchanged.
- Full PHP CI green locally (PHPStan level max + strict rules, cs-fixer, rector, 831 unit tests).