### PR TITLE
Seed an English source catalogue for tests against a source webtrees

### DIFF
--- a/src/Support/Aggregator/LabelSorter.php
+++ b/src/Support/Aggregator/LabelSorter.php
@@ -13,7 +13,11 @@ namespace MagicSunday\Webtrees\Statistic\Support\Aggregator;
 
 use Fisharebest\Webtrees\I18N;
 
+use function restore_error_handler;
+use function set_error_handler;
 use function uksort;
+
+use const E_USER_DEPRECATED;
 
 /**
  * Orders a `label => count` distribution alphabetically by its display label
@@ -44,7 +48,19 @@ final readonly class LabelSorter
      */
     public static function byLabel(array $map, ?string $pinLast = null): array
     {
-        $comparator = I18N::comparator();
+        // webtrees marks I18N::comparator() deprecated on dev-main (removed in 2.3,
+        // superseded by I18N::compare()), but compare() does not exist on the 2.2.x
+        // line this module also supports — so comparator() stays the only portable
+        // call. Swallow the transitional E_USER_DEPRECATED at this single call site
+        // (a scoped handler restored immediately after) so it neither fails the suite
+        // nor leaks as test output; migrate to compare() once the 2.2.x floor is dropped.
+        set_error_handler(static fn (): bool => true, E_USER_DEPRECATED);
+
+        try {
+            $comparator = I18N::comparator();
+        } finally {
+            restore_error_handler();
+        }
 
         uksort(
             $map,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,7 @@
 declare(strict_types=1);
 
 use Fisharebest\Webtrees\Webtrees;
+use RuntimeException;
 
 /*
  * PHPUnit bootstrap.
@@ -42,9 +43,13 @@ require_once __DIR__ . '/../stubs/hh_occupation_standardizer.stub';
 $enCatalogue = Webtrees::ROOT_DIR . 'resources/lang/en-US/messages.php';
 
 if (!is_file($enCatalogue)) {
-    if (!is_dir(dirname($enCatalogue))) {
-        mkdir(dirname($enCatalogue), 0o755, true);
+    $directory = dirname($enCatalogue);
+
+    if (!is_dir($directory) && !mkdir($directory, 0o755, true) && !is_dir($directory)) {
+        throw new RuntimeException(sprintf('Unable to create the language directory "%s".', $directory));
     }
 
-    file_put_contents($enCatalogue, "<?php\n\nreturn [];\n");
+    if (file_put_contents($enCatalogue, "<?php\n\nreturn [];\n") === false) {
+        throw new RuntimeException(sprintf('Unable to seed the English source catalogue "%s".', $enCatalogue));
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,8 @@
 
 declare(strict_types=1);
 
+use Fisharebest\Webtrees\Webtrees;
+
 /*
  * PHPUnit bootstrap.
  *
@@ -22,3 +24,27 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../.build/vendor/autoload.php';
 require_once __DIR__ . '/../stubs/hh_occupation_standardizer.stub';
+
+/*
+ * Seed an English source catalogue when webtrees is installed from source.
+ *
+ * On a dev-main install, webtrees' composer dist archive ships no usable
+ * English catalogue: the built messages.php catalogues were dropped upstream
+ * (webtrees now generates them during its own build), and the messages.po
+ * sources are export-ignored from the archive. With neither present,
+ * I18N::init('en-US') reaches array_filter(false) deep in
+ * fisharebest/localization and every test that initialises the translator dies
+ * with a TypeError. English is the source language (msgid === msgstr), so a
+ * translator backed by an empty catalogue is the correct, behaviourally
+ * identical stand-in; a release checkout that already carries the real file is
+ * left untouched.
+ */
+$enCatalogue = Webtrees::ROOT_DIR . 'resources/lang/en-US/messages.php';
+
+if (!is_file($enCatalogue)) {
+    if (!is_dir(dirname($enCatalogue))) {
+        mkdir(dirname($enCatalogue), 0o755, true);
+    }
+
+    file_put_contents($enCatalogue, "<?php\n\nreturn [];\n");
+}


### PR DESCRIPTION
## Problem

CI went red across every job when webtrees is installed **from source** (the `~2.2.0 || dev-main` constraint currently resolves to `dev-main`, because webtrees 2.2.6's exact dependency pins are unsatisfiable against the newer dev-toolchain deps under `minimum-stability: dev`). Two distinct upstream changes on webtrees dev-main broke the build:

1. **Missing English catalogue** — the built `resources/lang/*/messages.php` catalogues were dropped upstream (webtrees now generates them during its own build), and the `resources/lang/*/messages.po` sources have long been `export-ignore`d from the dist archive. With neither present, `I18N::init('en-US')` — called from the test bootstrap of every suite — reaches `array_filter(false)` deep in `fisharebest/localization` and dies with 384× `TypeError`.
2. **`I18N::comparator()` deprecation** — webtrees dev-main deprecates `I18N::comparator()` (removed in 2.3, superseded by `I18N::compare()`), which `LabelSorter` uses. The runtime `E_USER_DEPRECATED` fails the suite (`failOnDeprecation`) and leaks as test output (`beStrictAboutOutputDuringTests`).

## Fix

1. Seed an empty English catalogue from the PHPUnit bootstrap when webtrees carries none. English is the source language (`msgid === msgstr`), so a translator backed by an empty catalogue is behaviourally identical. A release checkout that already carries the real file is left untouched.
2. `compare()` does not exist on the 2.2.x line this module also supports, so `comparator()` stays the only portable call. Swallow the transitional deprecation with a scoped error handler around the single call site, restored immediately after; migrate to `compare()` once the 2.2.x floor is dropped.

## Verification

Full unit suite green against a real dev-main webtrees (composer-installed in an isolated worktree): `OK (831 tests, 3690 assertions)`, **0 risky, 0 deprecations**. `composer ci:test` (phpstan/rector/cgl/biome) clean.