### PR TITLE
GH-247: Remove documentation for a deleted module and a superseded workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,15 @@ All d3 modules are runtime `dependencies` in `package.json` — `d3-array`, `d3-
 - One class per file. Write tests for every class with **real value-equality assertions against curated fixtures**, not just shape checks — the `assertGreaterThan(0)` style hides regressions where the iterator shape changed but the count happens to land near zero. Use PHPUnit `#[Test]` attributes (not docblock annotations).
 - Prefer `array_find` / `array_any` / `array_all` over manual `foreach` for "find one" / "any match" / "all match" intents — but only on PHP 8.4+. While `composer.json` still allows PHP 8.3, manual `foreach` stays the portable form; do not introduce these calls until the floor moves to 8.4.
 
+## Commits & PRs
+- Commit subjects match `^(GH-<N>: )?[A-ZÄÖÜ]` — a capitalised imperative, with the
+  `GH-<N>: ` prefix on issue-tied work. **No conventional-commit prefixes**
+  (`feat:`, `fix:`, `chore:` …), no lowercase or path-like starts. Branches for an
+  issue are named exactly `GH-<N>`.
+- Never add a `Co-Authored-By:` trailer or any other AI attribution.
+- One concern per commit; style-only fixes stay separate from behaviour changes.
+- Every issue carries a type label **and** a `priority:` label from this repository's own set.
+
 ## Audit-loop discipline
 - Every issue umsetzen: spawn ALL relevant reviewers (correctness + maintainability + testing + project-standards always; conditional ones — adversarial / kieran / reliability / security / frontend — whenever their triggers match) in parallel before committing. Iterate fix → audit until 2× zero findings AND local `composer ci:test` green.
 - Keep `AGENTS.md` and the README in lockstep with code changes. If a section here references a behaviour the code no longer has, fix the doc in the same commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,6 @@ Three-folder layout mirroring the chart modules' kebab-case convention:
 
 ### JS (`resources/js/modules/`)
 - **`index.js`** — exports `renderWidgets(root)`. Scans every `[data-widget]` element, parses `data-payload` / `data-options` JSON, and dispatches to the registered draw function. The world-map dispatch is async because it fetches the GeoJSON (cached per page load) before instantiating the chart-lib widget. Also initialises Bootstrap popovers attached to chart-header info buttons after each render.
-- **`dashboard-bus.js`** — Shared selection observable (see Cross-widget selection bus section below).
 
 All d3 modules are runtime `dependencies` in `package.json` — `d3-array`, `d3-axis`, `d3-ease`, `d3-fetch`, `d3-geo`, `d3-interpolate`, `d3-sankey`, `d3-scale`, `d3-scale-chromatic`, `d3-selection`, `d3-shape`, `d3-transition` — and are bundled into the UMD output by `@rollup/plugin-node-resolve` (they are not declared `external` in `rollup.config.js`).
 
@@ -170,7 +169,7 @@ All d3 modules are runtime `dependencies` in `package.json` — `d3-array`, `d3-
     2. `lang-merge`: `msgmerge` reconciles each locale's `messages.po` with the fresh POT, `msginit`-seeds any missing locale entry.
     3. `lang-resolve-fuzzy`: `dev/fuzzy-resolver.py` auto-clears fuzzy entries whose only change from the previous msgid is a trivial punctuation diff; non-trivial diffs stay fuzzy and surface as a list.
     4. `lang-compile`: `msgfmt` produces every `messages.mo` from its sibling `messages.po`. Webtrees core reads the MO at runtime via the module's resource loader.
-- The `*.pot` file is gitignored; PO + MO are committed. Adding a new locale: append the language code to the `LOCALES :=` list in `Make/lang.mk`, then run `make lang` once.
+- The `*.pot` file is gitignored; PO + MO are committed. Adding a new locale: create `resources/lang/<code>/messages.po` and run `make lang` once. `LOCALES` in `Make/lang.mk` is discovered from the existing per-locale directories, so no Makefile edit is needed.
 
 ## Key patterns
 - **Bucket precedence (per individual)**: current > divorced > widowed > single. Applied in `FamilyRepository::classifyOneIndividual()` so a remarried-after-widowed living person is classed as "current", not "widowed".
@@ -185,30 +184,6 @@ All d3 modules are runtime `dependencies` in `package.json` — `d3-array`, `d3-
 - **Plain-name labels**: `Individual::fullName()` / `Family::fullName()` return HTML markup (`<span class="NAME">…</span>`), which must be reduced to plain text before a name reaches a view (the partials just `e()`-escape the already-resolved `label`). Two accessors do this: the module's own `Support\Gedcom\RecordName::plain()` — used by the ranking / podium repositories (`FamilyRankingRepository`, `MarriageRepository`, `GenerationDepthRepository`, `FamilyRepository`) to plain the entity labels feeding the `progress-list` / `podium` partials — and module-base's `NameProcessor::getFullName()`, used by `LifeSpanRepository` for the oldest-individual record names.
 - **Privacy of Top-N / record widgets**: podium and single-record widgets rank on raw counts and keep every row in place — they never call `canShow()` to drop a row (that would shift ranks and surface a smaller-than-N podium). The name is privatised by `fullName()`, which substitutes webtrees' own "Private" placeholder when the viewer lacks access, and the ranked metric (count / age / duration) is always rendered. **Any additional sensitive attribute a row carries beyond the ranked metric must be gated on the resolved record's `canShow()` and suppressed (`null`) when the record is not visible** — name privatisation alone is not enough, because the surrounding fact can be more sensitive than a name plus a number. Today the only such attribute is the marriage end-cause (death vs divorce) in `MarriageRepository::getMarriageDurationExtremes()`; future record widgets that render an extra sensitive fact follow the same gate.
 - **Single chart tooltip element on `document.body`**: every chart-lib widget that supports hover-tooltips uses `createChartTooltip()` from chart-lib — one shared `position: fixed` element across the whole page, clamped to viewport edges, flipped above-cursor / left-of-cursor when the preferred placement would overflow.
-
-## Cross-widget selection bus
-
-`resources/js/modules/dashboard-bus.js` exposes a `DashboardBus` class — a tiny d3-dispatch wrapper that lets one widget broadcast a selection (e.g. "show me only the 1900s century") and every subscribed widget rebroadcast / re-filter against the same predicate.
-
-### Contract
-- `bus.emit({ source: "donut.births-century", predicate: { century: 1900 } })` — broadcast.
-- `bus.onSelectionChanged(callback)` — subscribe. Returns an `unsubscribe` function for clean teardown.
-- A `null` predicate means "clear filter".
-- Every subscriber receives every event. Callers ignore their own emissions by matching the `source` string.
-
-### Sequence
-```
-+--------+         +---------------+         +-----------+   +-----------+
-| Widget |--emit-->| DashboardBus  |--fanout-| Widget A  |   | Widget B  |
-| (donut)|         | (selection)   |--fanout-| (sankey)  |   | (heatmap) |
-+--------+         +---------------+         +-----------+   +-----------+
-```
-
-The bus carries no data shape — each widget interprets the predicate against its own dataset. This keeps the bus itself ~50 lines and pushes the schema decision to the widget pair that actually shares semantics (e.g. century filter only makes sense between widgets that bucket by century).
-
-### Status
-- The bus + 5 jest tests covering multi-subscriber broadcast, unsubscribe, null-predicate, and source-self-ignore contracts is shipped.
-- Widget-side wiring (donut slice click → bus.emit, sankey re-filter on incoming selection) is tracked in issue #14 + chart-lib#10 + stats#33 — chart-lib widgets need an `onSelectionChanged` hook before the pilot wiring lands.
 
 ## Design principles
 - Priority order on conflict: **KISS > SOLID > DRY > YAGNI > GRASP > Law of Demeter > Separation of Concerns > Convention over Configuration**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,14 +203,22 @@ All d3 modules are runtime `dependencies` in `package.json` — `d3-array`, `d3-
       `GH-12: fix typo` would pass. Keying on the subject rather than on the branch
       also keeps this check decidable for commits already on `main`, where the issue
       branch no longer exists.
+    - The same two patterns apply to the **pull-request title**, which under
+      squash-merge is the subject that reaches `main`.
     - The normative definition lives in
       `magicsunday/.github/.github/workflows/commit-convention.yml@main`, which
-      self-tests a decision table before applying it. This repository does not call
-      that gate yet — fan-chart is piloting it — so the rule here is documentation
-      only.
+      self-tests a decision table before applying it. No workflow here calls that
+      gate, so the rule in this repository is documentation only; wherever it is
+      wired, the workflow is authoritative and this text is what gets fixed.
 - Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
-  Commits on such a branch must carry the `GH-<N>: ` subject prefix, except the merge
-  and revert commits git writes itself — those keep their generated subject.
+  The `GH-<N>: ` prefix marks work that belongs to the issue — a commit on that
+  branch whose concern is something else (a drive-by lint fix, a catalogue resync)
+  keeps its own unprefixed subject, which is what the history actually does. Merge
+  and revert commits keep the subject git generates. Not every git-written subject
+  is exempt, though: `fixup!` and `squash!` start lowercase and violate the rule, so
+  autosquash them before opening the PR.
+- The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject
+  prefix is not a GitHub link and closes nothing.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.
 - One concern per commit; style-only fixes stay separate from behaviour changes.
 - Every issue carries a type label **and** a `priority:` label from this repository's own set.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,10 +192,25 @@ All d3 modules are runtime `dependencies` in `package.json` — `d3-array`, `d3-
 - Prefer `array_find` / `array_any` / `array_all` over manual `foreach` for "find one" / "any match" / "all match" intents — but only on PHP 8.4+. While `composer.json` still allows PHP 8.3, manual `foreach` stays the portable form; do not introduce these calls until the floor moves to 8.4.
 
 ## Commits & PRs
-- Commit subjects match `^(GH-<N>: )?[A-ZÄÖÜ]` — a capitalised imperative, with the
-  `GH-<N>: ` prefix on issue-tied work. **No conventional-commit prefixes**
-  (`feat:`, `fix:`, `chore:` …), no lowercase or path-like starts. Branches for an
-  issue are named exactly `GH-<N>`.
+- A subject starting with `GH-` must match `^GH-\d+: [A-ZÄÖÜ]`; every other subject
+  must match `^[A-ZÄÖÜ]` — a capitalised imperative either way. The patterns check
+  only the leading capital; two starts are banned whatever their case:
+  **conventional-commit prefixes** (`feat:`, `Fix:`, `chore:` …) and path-like starts
+  (`src/Module.php: …`, `Src/Module.php: …`).
+    - The two patterns are deliberately kept separate: `^(GH-\d+: )?[A-ZÄÖÜ]` (wrong)
+      stops enforcing the capital *after* the prefix, because the optional group can
+      be skipped and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]` on its own —
+      `GH-12: fix typo` would pass. Keying on the subject rather than on the branch
+      also keeps this check decidable for commits already on `main`, where the issue
+      branch no longer exists.
+    - The normative definition lives in
+      `magicsunday/.github/.github/workflows/commit-convention.yml@main`, which
+      self-tests a decision table before applying it. This repository does not call
+      that gate yet — fan-chart is piloting it — so the rule here is documentation
+      only.
+- Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
+  Commits on such a branch must carry the `GH-<N>: ` subject prefix, except the merge
+  and revert commits git writes itself — those keep their generated subject.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.
 - One concern per commit; style-only fixes stay separate from behaviour changes.
 - Every issue carries a type label **and** a `priority:` label from this repository's own set.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ All d3 modules are runtime `dependencies` in `package.json` — `d3-array`, `d3-
     2. `lang-merge`: `msgmerge` reconciles each locale's `messages.po` with the fresh POT, `msginit`-seeds any missing locale entry.
     3. `lang-resolve-fuzzy`: `dev/fuzzy-resolver.py` auto-clears fuzzy entries whose only change from the previous msgid is a trivial punctuation diff; non-trivial diffs stay fuzzy and surface as a list.
     4. `lang-compile`: `msgfmt` produces every `messages.mo` from its sibling `messages.po`. Webtrees core reads the MO at runtime via the module's resource loader.
-- The `*.pot` file is gitignored; PO + MO are committed. Adding a new locale: create `resources/lang/<code>/messages.po` and run `make lang` once. `LOCALES` in `Make/lang.mk` is discovered from the existing per-locale directories, so no Makefile edit is needed.
+- The `*.pot` file is gitignored; PO + MO are committed. Adding a new locale: create the **directory** `resources/lang/<code>/` — empty — and run `make lang` once. `LOCALES` is globbed from the per-locale directories, so the directory alone is enough to be discovered and no Makefile edit is needed. Do not create `messages.po` yourself: `lang-merge` seeds it with `msginit` only when it does not exist, and a file you placed there takes the `msgmerge` branch instead, which has no catalogue header to merge against. For a region or script tag (`en-US`, `zh-Hans`) msginit leaves the `Plural-Forms` placeholder — set `nplurals`/`plural` once by hand; msgmerge preserves it afterwards.
 
 ## Key patterns
 - **Bucket precedence (per individual)**: current > divorced > widowed > single. Applied in `FamilyRepository::classifyOneIndividual()` so a remarried-after-widowed living person is classed as "current", not "widowed".


### PR DESCRIPTION
Fixes #247

## A module that was deleted a while ago

`AGENTS.md` listed `dashboard-bus.js` among the JS modules and devoted a 33-line *Cross-widget selection bus* section to its `DashboardBus` contract.

```
git log --diff-filter=A -- resources/js/modules/dashboard-bus.js
  078c2bd Crossfilter dashboard bus (infrastructure-only)
git log --diff-filter=D -- resources/js/modules/dashboard-bus.js
  671f902 Remove the orphaned crossfilter dashboard-bus and fix misleading cursors (#158)
```

`grep -rn "DashboardBus|dashboard-bus"` over `resources/js/`, `src/` and `resources/views/` returns nothing. Anyone reading the file would look for a coordination mechanism that is not there — or build against a contract with no implementation.

## A workflow that was automated away

The file told contributors to append the language code to `LOCALES :=` in `Make/lang.mk`. That list is discovered by wildcard:

```make
LOCALES := $(notdir $(patsubst %/,%,$(wildcard resources/lang/*/)))
```

Its own comment states the intent: a community PR adding `resources/lang/<new>/messages.po` is merged and compiled without a Makefile edit. The documented step is not merely redundant — it points at a line that no longer has that form.

## Worth noting

`AGENTS.md` carries this rule about itself:

> Keep `AGENTS.md` and the README in lockstep with code changes. If a section here references a behaviour the code no longer has, fix the doc in the same commit.

That did not happen when the module was deleted, which is how a 33-line section outlived its subject.

## Scope

Both items came from a targeted check — documented paths against the filesystem, documented workflow against the Makefile. A fuller pass over the remaining claims is worthwhile; #247 notes it but this PR does not attempt it.