### PR TITLE
GH-254: Drop the removed baseUrl option from jsconfig

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -12,8 +12,6 @@
         "strictNullChecks": false,
         "lib": ["ES2022", "DOM"],
         "types": ["jest"],
-        "ignoreDeprecations": "6.0",
-        "baseUrl": ".",
         "paths": {
             "resources/js/modules/*": ["./resources/js/modules/*"]
         }

--- a/resources/js/modules/index.js
+++ b/resources/js/modules/index.js
@@ -67,13 +67,32 @@ async function loadWorldGeoJson() {
 }
 
 /**
+ * The renderer options as they cross the PHTML -> JSON -> JS boundary: the
+ * partial supplies `width`, `height` and `accent`, the dispatcher adds
+ * `emptyMessage` and `animateOnReveal`, and chart-lib's widget constructors
+ * declare the receiving end.
+ *
+ * Spelled out rather than left open: an option renamed on either side crosses
+ * three hops that nothing else checks, and a bare `object` — or an index
+ * signature — would let the rename through silently.
+ *
+ * @typedef {object} WidgetOptions
+ *
+ * @property {number}  [width]
+ * @property {number}  [height]
+ * @property {string}  [accent]
+ * @property {string}  [emptyMessage]
+ * @property {boolean} [animateOnReveal]
+ */
+
+/**
  * Adapter that turns a chart-lib widget class (`new Widget(node,
  * opts).draw(data)`) into the functional `(node, data, options)` shape the
  * dispatcher uses. Keeps the dispatch table flat.
  *
- * @param {{new (node: HTMLElement, options: object): {draw: (data: unknown) => unknown}}} Widget Chart-lib widget class.
+ * @param {{new (node: HTMLElement, options: WidgetOptions): {draw: (data: unknown) => unknown}}} Widget Chart-lib widget class.
  *
- * @returns {(node: HTMLElement, data: unknown, options: object) => unknown}
+ * @returns {(node: HTMLElement, data: unknown, options: WidgetOptions) => unknown}
  */
 function fromChartLib(Widget) {
     return (node, data, options) => {
@@ -89,9 +108,10 @@ function fromChartLib(Widget) {
  * projection. Same async return shape as the other widgets even though they
  * resolve synchronously, so callers never have to special-case the map.
  *
- * @param {HTMLElement} node
- * @param {unknown}     data
- * @param {object}      options
+ * @param {HTMLElement}   node
+ * @param {unknown}       data
+ * @param {WidgetOptions} options Only `emptyMessage` is read here; the rest is
+ *                                spread into the widget untouched.
  *
  * @returns {Promise<unknown>}
  */
@@ -134,7 +154,7 @@ async function drawWorldMap(node, data, options) {
  * Every widget is a chart-lib widget; the world map just needs a pre-fetch hop
  * to load the GeoJSON the widget consumes via its constructor.
  *
- * @type {Object<string, (node: HTMLElement, data: unknown, options: object) => unknown>}
+ * @type {Object<string, (node: HTMLElement, data: unknown, options: WidgetOptions) => unknown>}
  */
 const WIDGETS = {
     "donut-chart": fromChartLib(DonutChart),
@@ -197,6 +217,7 @@ export function renderWidgets(root) {
     // A Map (not a WeakMap) so a late `prefers-reduced-motion` toggle can iterate
     // the still-held entries and fast-forward them; entries are removed as each
     // card reveals, and the whole map is cleared on teardown.
+    /** @type {Map<Element, {playEntry?: () => void}>|null} */
     const held = revealOnScroll ? new Map() : null;
     // Collected during the draw pass and revealed in a second pass, so the
     // getBoundingClientRect reads batch into a single layout flush instead of
@@ -213,7 +234,7 @@ export function renderWidgets(root) {
      * Play a widget's held entrance if it exposes one. Idempotent — BaseWidget
      * clears the stored entry after the first call.
      *
-     * @param {object|null|undefined} instance
+     * @param {{playEntry?: () => void}|null|undefined} instance
      *
      * @returns {void}
      */
@@ -254,8 +275,8 @@ export function renderWidgets(root) {
      * page that cannot scroll the observer's trigger line into reach, which
      * would otherwise leave it invisible forever — else defer to the observer.
      *
-     * @param {Element}               node
-     * @param {object|null|undefined} instance
+     * @param {Element}                                  node
+     * @param {{playEntry?: () => void}|null|undefined} instance
      *
      * @returns {void}
      */


### PR DESCRIPTION
Fixes #254

Every open pull request fails the **JS Typecheck** step on all three matrix legs — including one that changes only `AGENTS.md`, which is what made it clear the cause is not in the diffs under review.

```
jsconfig.json(16,9): error TS5102: Option "baseUrl" has been removed.
```

## Correction

An earlier revision of this description — and the original commit messages — blamed a caret range without a committed lockfile. **That was wrong.** `package-lock.json` is tracked and CI runs `npm ci`, so resolution is deterministic. The corrected account:

- The npm group bump moved `typescript` across a **major**: `6.0.3` -> `7.0.2`. A caret range cannot do that; the bump rewrote the pin in both `package.json` and the lockfile.
- That bump was merged while all three required `build (8.x)` checks were failing, which is what turned `main` red.
- It stayed invisible locally because a developer `node_modules` still held `6.0.3` while the lockfile pinned `7.0.2`. Stale `node_modules` against the lockfile — not range drift.
- The four `TS2339` errors are likewise a TypeScript 7 strictness change on property access against a bare `object`, not a consequence of removing `baseUrl`.

Verified by reproducing both revisions under 6.0.3 and 7.0.2.

## The change

**`jsconfig.json`** — TypeScript 7 removed `baseUrl`. It is not needed: since TypeScript 4.1 a standalone `paths` block resolves relative targets against the directory holding the config, and the mapping already reads `./resources/js/modules/*` — exactly what `baseUrl: "."` produced. `ignoreDeprecations` had been suppressing the deprecation that became this removal and is inert once the option is gone.

**`resources/js/modules/index.js`** — the four `TS2339` sites. Both already guard with `typeof`; only the declared types were wrong.

The options value is declared as the closed shape it is, rather than reopened with an index signature. An index signature would clear the error by disabling property checking on that parameter altogether — the same class of defect as the removed option, and it was measurably worse than the `object` it replaced. The shape crosses PHTML -> JSON -> JS: the partial supplies `width`, `height` and `accent`, the dispatcher adds `emptyMessage` and `animateOnReveal`, and chart-lib's constructor declares the receiving end. A rename on either side crosses three hops nothing else checks, so a shared `@typedef` keeps the four declarations from drifting apart.

`playEntry` gets the structural type its guard implies, and the `Map` feeding it is typed so the signature constrains a real caller.

## Out of scope, filed separately

The Dependabot `npm` group carries semver-majors of CI-gating tools in the same auto-mergeable pull request as patch bumps, and this one landed past red required checks. The typecheck also covers only `index.js` — the test directory is excluded by `include` and would surface further errors of the same class.