### PR TITLE
GH-239: Fold the age-bucket label rule back onto the shared helper

### DIFF
--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Repository/LifeSpanRepository.php:921
+#: src/Repository/LifeSpanRepository.php:915
 #, php-format
 msgid "%1$s %% (%2$s of %3$s individuals reached this age)"
 msgstr "%1$s %% (%2$s z %3$s osob dosáhlo tohoto věku)"
@@ -95,8 +95,8 @@ msgstr ""
 msgid "%1$s sub-trees total · the largest covers %2$s%% of all individuals"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:812
-#: src/Repository/LifeSpanRepository.php:819
+#: src/Repository/LifeSpanRepository.php:806
+#: src/Repository/LifeSpanRepository.php:813
 #: src/Repository/ParenthoodRepository.php:359
 #: src/Repository/ParenthoodRepository.php:372
 #, php-format
@@ -135,7 +135,7 @@ msgstr ""
 msgid "%1$s: %2$s deaths against an expected %3$s (Z-score %4$s)"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:1134
+#: src/Repository/LifeSpanRepository.php:1128
 #: src/Support/Locale/CenturyName.php:112
 #: src/Support/Locale/CenturyName.php:131 src/Support/Locale/DecadeName.php:53
 #: src/Support/Locale/DecadeName.php:84
@@ -865,7 +865,7 @@ msgstr "Po smrti partnera"
 msgid "Age"
 msgstr "Věk"
 
-#: src/Repository/LifeSpanRepository.php:919
+#: src/Repository/LifeSpanRepository.php:913
 #, php-format
 msgid "Age %s"
 msgstr "Věk %s"
@@ -1738,7 +1738,7 @@ msgid "February"
 msgstr "Únor"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:421
-#: src/Repository/LifeSpanRepository.php:841 src/Statistic.php:228
+#: src/Repository/LifeSpanRepository.php:835 src/Statistic.php:228
 msgid "Female"
 msgstr "Žena"
 
@@ -2262,7 +2262,7 @@ msgid "Longevity"
 msgstr "Longevity"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:420
-#: src/Repository/LifeSpanRepository.php:834 src/Statistic.php:223
+#: src/Repository/LifeSpanRepository.php:828 src/Statistic.php:223
 msgid "Male"
 msgstr "Muž"
 
@@ -3460,8 +3460,8 @@ msgctxt "count word"
 msgid "nine"
 msgstr "nine"
 
-#: src/Repository/LifeSpanRepository.php:816
-#: src/Repository/LifeSpanRepository.php:823
+#: src/Repository/LifeSpanRepository.php:810
+#: src/Repository/LifeSpanRepository.php:817
 #: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Repository/LifeSpanRepository.php:921
+#: src/Repository/LifeSpanRepository.php:915
 #, php-format
 msgid "%1$s %% (%2$s of %3$s individuals reached this age)"
 msgstr "%1$s %% (%2$s af %3$s personer nåede denne alder)"
@@ -94,8 +94,8 @@ msgstr ""
 msgid "%1$s sub-trees total · the largest covers %2$s%% of all individuals"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:812
-#: src/Repository/LifeSpanRepository.php:819
+#: src/Repository/LifeSpanRepository.php:806
+#: src/Repository/LifeSpanRepository.php:813
 #: src/Repository/ParenthoodRepository.php:359
 #: src/Repository/ParenthoodRepository.php:372
 #, php-format
@@ -134,7 +134,7 @@ msgstr ""
 msgid "%1$s: %2$s deaths against an expected %3$s (Z-score %4$s)"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:1134
+#: src/Repository/LifeSpanRepository.php:1128
 #: src/Support/Locale/CenturyName.php:112
 #: src/Support/Locale/CenturyName.php:131 src/Support/Locale/DecadeName.php:53
 #: src/Support/Locale/DecadeName.php:84
@@ -824,7 +824,7 @@ msgstr "Efter partnerens død"
 msgid "Age"
 msgstr "Alder"
 
-#: src/Repository/LifeSpanRepository.php:919
+#: src/Repository/LifeSpanRepository.php:913
 #, php-format
 msgid "Age %s"
 msgstr "Alder %s"
@@ -1701,7 +1701,7 @@ msgid "February"
 msgstr "Februar"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:421
-#: src/Repository/LifeSpanRepository.php:841 src/Statistic.php:228
+#: src/Repository/LifeSpanRepository.php:835 src/Statistic.php:228
 msgid "Female"
 msgstr "Kvinde"
 
@@ -2227,7 +2227,7 @@ msgid "Longevity"
 msgstr "Longevity"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:420
-#: src/Repository/LifeSpanRepository.php:834 src/Statistic.php:223
+#: src/Repository/LifeSpanRepository.php:828 src/Statistic.php:223
 msgid "Male"
 msgstr "Mand"
 
@@ -3424,8 +3424,8 @@ msgctxt "count word"
 msgid "nine"
 msgstr "nine"
 
-#: src/Repository/LifeSpanRepository.php:816
-#: src/Repository/LifeSpanRepository.php:823
+#: src/Repository/LifeSpanRepository.php:810
+#: src/Repository/LifeSpanRepository.php:817
 #: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Repository/LifeSpanRepository.php:921
+#: src/Repository/LifeSpanRepository.php:915
 #, php-format
 msgid "%1$s %% (%2$s of %3$s individuals reached this age)"
 msgstr "%1$s %% (%2$s von %3$s Personen erreichten dieses Alter)"
@@ -95,8 +95,8 @@ msgstr "%1$s Geschwister aus %2$s Familien"
 msgid "%1$s sub-trees total · the largest covers %2$s%% of all individuals"
 msgstr "%1$s Teilbäume gesamt · größter umfasst %2$s%% aller Personen"
 
-#: src/Repository/LifeSpanRepository.php:812
-#: src/Repository/LifeSpanRepository.php:819
+#: src/Repository/LifeSpanRepository.php:806
+#: src/Repository/LifeSpanRepository.php:813
 #: src/Repository/ParenthoodRepository.php:359
 #: src/Repository/ParenthoodRepository.php:372
 #, php-format
@@ -137,7 +137,7 @@ msgstr "%1$s: %2$s"
 msgid "%1$s: %2$s deaths against an expected %3$s (Z-score %4$s)"
 msgstr "%1$s: %2$s Sterbefälle gegenüber erwarteten %3$s (Z-Wert %4$s)"
 
-#: src/Repository/LifeSpanRepository.php:1134
+#: src/Repository/LifeSpanRepository.php:1128
 #: src/Support/Locale/CenturyName.php:112
 #: src/Support/Locale/CenturyName.php:131 src/Support/Locale/DecadeName.php:53
 #: src/Support/Locale/DecadeName.php:84
@@ -830,7 +830,7 @@ msgstr "Nach dem Tod des Partners"
 msgid "Age"
 msgstr "Alter"
 
-#: src/Repository/LifeSpanRepository.php:919
+#: src/Repository/LifeSpanRepository.php:913
 #, php-format
 msgid "Age %s"
 msgstr "Alter %s"
@@ -1815,7 +1815,7 @@ msgid "February"
 msgstr "Februar"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:421
-#: src/Repository/LifeSpanRepository.php:841 src/Statistic.php:228
+#: src/Repository/LifeSpanRepository.php:835 src/Statistic.php:228
 msgid "Female"
 msgstr "weiblich"
 
@@ -2391,7 +2391,7 @@ msgid "Longevity"
 msgstr "Langlebigkeit"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:420
-#: src/Repository/LifeSpanRepository.php:834 src/Statistic.php:223
+#: src/Repository/LifeSpanRepository.php:828 src/Statistic.php:223
 msgid "Male"
 msgstr "männlich"
 
@@ -3664,8 +3664,8 @@ msgctxt "count word"
 msgid "nine"
 msgstr "neun"
 
-#: src/Repository/LifeSpanRepository.php:816
-#: src/Repository/LifeSpanRepository.php:823
+#: src/Repository/LifeSpanRepository.php:810
+#: src/Repository/LifeSpanRepository.php:817
 #: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Repository/LifeSpanRepository.php:921
+#: src/Repository/LifeSpanRepository.php:915
 #, php-format
 msgid "%1$s %% (%2$s of %3$s individuals reached this age)"
 msgstr "%1$s %% (%2$s of %3$s individuals reached this age)"
@@ -94,8 +94,8 @@ msgstr ""
 msgid "%1$s sub-trees total · the largest covers %2$s%% of all individuals"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:812
-#: src/Repository/LifeSpanRepository.php:819
+#: src/Repository/LifeSpanRepository.php:806
+#: src/Repository/LifeSpanRepository.php:813
 #: src/Repository/ParenthoodRepository.php:359
 #: src/Repository/ParenthoodRepository.php:372
 #, php-format
@@ -134,7 +134,7 @@ msgstr ""
 msgid "%1$s: %2$s deaths against an expected %3$s (Z-score %4$s)"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:1134
+#: src/Repository/LifeSpanRepository.php:1128
 #: src/Support/Locale/CenturyName.php:112
 #: src/Support/Locale/CenturyName.php:131 src/Support/Locale/DecadeName.php:53
 #: src/Support/Locale/DecadeName.php:84
@@ -824,7 +824,7 @@ msgstr "After the partner's death"
 msgid "Age"
 msgstr "Age"
 
-#: src/Repository/LifeSpanRepository.php:919
+#: src/Repository/LifeSpanRepository.php:913
 #, php-format
 msgid "Age %s"
 msgstr "Age %s"
@@ -1702,7 +1702,7 @@ msgid "February"
 msgstr "February"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:421
-#: src/Repository/LifeSpanRepository.php:841 src/Statistic.php:228
+#: src/Repository/LifeSpanRepository.php:835 src/Statistic.php:228
 msgid "Female"
 msgstr "Female"
 
@@ -2215,7 +2215,7 @@ msgid "Longevity"
 msgstr "Longevity"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:420
-#: src/Repository/LifeSpanRepository.php:834 src/Statistic.php:223
+#: src/Repository/LifeSpanRepository.php:828 src/Statistic.php:223
 msgid "Male"
 msgstr "Male"
 
@@ -3412,8 +3412,8 @@ msgctxt "count word"
 msgid "nine"
 msgstr "nine"
 
-#: src/Repository/LifeSpanRepository.php:816
-#: src/Repository/LifeSpanRepository.php:823
+#: src/Repository/LifeSpanRepository.php:810
+#: src/Repository/LifeSpanRepository.php:817
 #: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Repository/LifeSpanRepository.php:921
+#: src/Repository/LifeSpanRepository.php:915
 #, php-format
 msgid "%1$s %% (%2$s of %3$s individuals reached this age)"
 msgstr "%1$s %% (%2$s sur %3$s personnes ont atteint cet âge)"
@@ -97,8 +97,8 @@ msgstr ""
 "%1$s sous-arbres au total · le plus grand d'entre eux regroupe %2$s%% de "
 "l'ensemble des individus"
 
-#: src/Repository/LifeSpanRepository.php:812
-#: src/Repository/LifeSpanRepository.php:819
+#: src/Repository/LifeSpanRepository.php:806
+#: src/Repository/LifeSpanRepository.php:813
 #: src/Repository/ParenthoodRepository.php:359
 #: src/Repository/ParenthoodRepository.php:372
 #, php-format
@@ -138,7 +138,7 @@ msgstr "%1$s: %2$s"
 msgid "%1$s: %2$s deaths against an expected %3$s (Z-score %4$s)"
 msgstr "%1$s : %2$s décès contre %3$s attendus (Z-score de %4$s)"
 
-#: src/Repository/LifeSpanRepository.php:1134
+#: src/Repository/LifeSpanRepository.php:1128
 #: src/Support/Locale/CenturyName.php:112
 #: src/Support/Locale/CenturyName.php:131 src/Support/Locale/DecadeName.php:53
 #: src/Support/Locale/DecadeName.php:84
@@ -832,7 +832,7 @@ msgstr "Après le décès du partenaire"
 msgid "Age"
 msgstr "Âge"
 
-#: src/Repository/LifeSpanRepository.php:919
+#: src/Repository/LifeSpanRepository.php:913
 #, php-format
 msgid "Age %s"
 msgstr "Âge %s"
@@ -1840,7 +1840,7 @@ msgid "February"
 msgstr "Février"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:421
-#: src/Repository/LifeSpanRepository.php:841 src/Statistic.php:228
+#: src/Repository/LifeSpanRepository.php:835 src/Statistic.php:228
 msgid "Female"
 msgstr "Féminin"
 
@@ -2430,7 +2430,7 @@ msgid "Longevity"
 msgstr "Longévité"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:420
-#: src/Repository/LifeSpanRepository.php:834 src/Statistic.php:223
+#: src/Repository/LifeSpanRepository.php:828 src/Statistic.php:223
 msgid "Male"
 msgstr "Masculin"
 
@@ -3722,8 +3722,8 @@ msgctxt "count word"
 msgid "nine"
 msgstr "neuf"
 
-#: src/Repository/LifeSpanRepository.php:816
-#: src/Repository/LifeSpanRepository.php:823
+#: src/Repository/LifeSpanRepository.php:810
+#: src/Repository/LifeSpanRepository.php:817
 #: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378

--- a/resources/lang/it/messages.po
+++ b/resources/lang/it/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Repository/LifeSpanRepository.php:921
+#: src/Repository/LifeSpanRepository.php:915
 #, php-format
 msgid "%1$s %% (%2$s of %3$s individuals reached this age)"
 msgstr "%1$s %% (%2$s su %3$s persone hanno raggiunto questa età)"
@@ -95,8 +95,8 @@ msgstr ""
 msgid "%1$s sub-trees total · the largest covers %2$s%% of all individuals"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:812
-#: src/Repository/LifeSpanRepository.php:819
+#: src/Repository/LifeSpanRepository.php:806
+#: src/Repository/LifeSpanRepository.php:813
 #: src/Repository/ParenthoodRepository.php:359
 #: src/Repository/ParenthoodRepository.php:372
 #, php-format
@@ -135,7 +135,7 @@ msgstr ""
 msgid "%1$s: %2$s deaths against an expected %3$s (Z-score %4$s)"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:1134
+#: src/Repository/LifeSpanRepository.php:1128
 #: src/Support/Locale/CenturyName.php:112
 #: src/Support/Locale/CenturyName.php:131 src/Support/Locale/DecadeName.php:53
 #: src/Support/Locale/DecadeName.php:84
@@ -825,7 +825,7 @@ msgstr "Dopo la morte del partner"
 msgid "Age"
 msgstr "Età"
 
-#: src/Repository/LifeSpanRepository.php:919
+#: src/Repository/LifeSpanRepository.php:913
 #, php-format
 msgid "Age %s"
 msgstr "Età %s"
@@ -1708,7 +1708,7 @@ msgid "February"
 msgstr "Febbraio"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:421
-#: src/Repository/LifeSpanRepository.php:841 src/Statistic.php:228
+#: src/Repository/LifeSpanRepository.php:835 src/Statistic.php:228
 msgid "Female"
 msgstr "Femmina"
 
@@ -2241,7 +2241,7 @@ msgid "Longevity"
 msgstr "Longevità"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:420
-#: src/Repository/LifeSpanRepository.php:834 src/Statistic.php:223
+#: src/Repository/LifeSpanRepository.php:828 src/Statistic.php:223
 msgid "Male"
 msgstr "Maschio"
 
@@ -3447,8 +3447,8 @@ msgctxt "count word"
 msgid "nine"
 msgstr "nove"
 
-#: src/Repository/LifeSpanRepository.php:816
-#: src/Repository/LifeSpanRepository.php:823
+#: src/Repository/LifeSpanRepository.php:810
+#: src/Repository/LifeSpanRepository.php:817
 #: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Repository/LifeSpanRepository.php:921
+#: src/Repository/LifeSpanRepository.php:915
 #, php-format
 msgid "%1$s %% (%2$s of %3$s individuals reached this age)"
 msgstr "%1$s %% (%2$s av %3$s personer nådde denne alderen)"
@@ -94,8 +94,8 @@ msgstr ""
 msgid "%1$s sub-trees total · the largest covers %2$s%% of all individuals"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:812
-#: src/Repository/LifeSpanRepository.php:819
+#: src/Repository/LifeSpanRepository.php:806
+#: src/Repository/LifeSpanRepository.php:813
 #: src/Repository/ParenthoodRepository.php:359
 #: src/Repository/ParenthoodRepository.php:372
 #, php-format
@@ -134,7 +134,7 @@ msgstr ""
 msgid "%1$s: %2$s deaths against an expected %3$s (Z-score %4$s)"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:1134
+#: src/Repository/LifeSpanRepository.php:1128
 #: src/Support/Locale/CenturyName.php:112
 #: src/Support/Locale/CenturyName.php:131 src/Support/Locale/DecadeName.php:53
 #: src/Support/Locale/DecadeName.php:84
@@ -824,7 +824,7 @@ msgstr "Etter partnerens død"
 msgid "Age"
 msgstr "Alder"
 
-#: src/Repository/LifeSpanRepository.php:919
+#: src/Repository/LifeSpanRepository.php:913
 #, php-format
 msgid "Age %s"
 msgstr "Alder %s"
@@ -1700,7 +1700,7 @@ msgid "February"
 msgstr "Februar"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:421
-#: src/Repository/LifeSpanRepository.php:841 src/Statistic.php:228
+#: src/Repository/LifeSpanRepository.php:835 src/Statistic.php:228
 msgid "Female"
 msgstr "Kvinne"
 
@@ -2226,7 +2226,7 @@ msgid "Longevity"
 msgstr "Longevity"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:420
-#: src/Repository/LifeSpanRepository.php:834 src/Statistic.php:223
+#: src/Repository/LifeSpanRepository.php:828 src/Statistic.php:223
 msgid "Male"
 msgstr "Mann"
 
@@ -3423,8 +3423,8 @@ msgctxt "count word"
 msgid "nine"
 msgstr "nine"
 
-#: src/Repository/LifeSpanRepository.php:816
-#: src/Repository/LifeSpanRepository.php:823
+#: src/Repository/LifeSpanRepository.php:810
+#: src/Repository/LifeSpanRepository.php:817
 #: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Repository/LifeSpanRepository.php:921
+#: src/Repository/LifeSpanRepository.php:915
 #, php-format
 msgid "%1$s %% (%2$s of %3$s individuals reached this age)"
 msgstr "%1$s %% (%2$s van %3$s personen bereikten deze leeftijd)"
@@ -95,8 +95,8 @@ msgstr "%1$s broers/zussen uit %2$s gezinnen"
 msgid "%1$s sub-trees total · the largest covers %2$s%% of all individuals"
 msgstr "%1$s deelbomen totaal · de grootste omvat %2$s%% van alle personen"
 
-#: src/Repository/LifeSpanRepository.php:812
-#: src/Repository/LifeSpanRepository.php:819
+#: src/Repository/LifeSpanRepository.php:806
+#: src/Repository/LifeSpanRepository.php:813
 #: src/Repository/ParenthoodRepository.php:359
 #: src/Repository/ParenthoodRepository.php:372
 #, php-format
@@ -137,7 +137,7 @@ msgstr "%1$s: %2$s"
 msgid "%1$s: %2$s deaths against an expected %3$s (Z-score %4$s)"
 msgstr "%1$s: %2$s overlijdens tegenover een verwachte %3$s (Z-score %4$s)"
 
-#: src/Repository/LifeSpanRepository.php:1134
+#: src/Repository/LifeSpanRepository.php:1128
 #: src/Support/Locale/CenturyName.php:112
 #: src/Support/Locale/CenturyName.php:131 src/Support/Locale/DecadeName.php:53
 #: src/Support/Locale/DecadeName.php:84
@@ -830,7 +830,7 @@ msgstr "Na het overlijden van de partner"
 msgid "Age"
 msgstr "Leeftijd"
 
-#: src/Repository/LifeSpanRepository.php:919
+#: src/Repository/LifeSpanRepository.php:913
 #, php-format
 msgid "Age %s"
 msgstr "Leeftijd %s"
@@ -1827,7 +1827,7 @@ msgid "February"
 msgstr "Februari"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:421
-#: src/Repository/LifeSpanRepository.php:841 src/Statistic.php:228
+#: src/Repository/LifeSpanRepository.php:835 src/Statistic.php:228
 msgid "Female"
 msgstr "Vrouw"
 
@@ -2410,7 +2410,7 @@ msgid "Longevity"
 msgstr "Levensduur"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:420
-#: src/Repository/LifeSpanRepository.php:834 src/Statistic.php:223
+#: src/Repository/LifeSpanRepository.php:828 src/Statistic.php:223
 msgid "Male"
 msgstr "Man"
 
@@ -3692,8 +3692,8 @@ msgctxt "count word"
 msgid "nine"
 msgstr "negen"
 
-#: src/Repository/LifeSpanRepository.php:816
-#: src/Repository/LifeSpanRepository.php:823
+#: src/Repository/LifeSpanRepository.php:810
+#: src/Repository/LifeSpanRepository.php:817
 #: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378

--- a/resources/lang/pl/messages.po
+++ b/resources/lang/pl/messages.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Poedit-SearchPath-1: resources/views\n"
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: src/Repository/LifeSpanRepository.php:921
+#: src/Repository/LifeSpanRepository.php:915
 #, php-format
 msgid "%1$s %% (%2$s of %3$s individuals reached this age)"
 msgstr "%1$s %% (%2$s z %3$s osób osiągnęło ten wiek)"
@@ -96,8 +96,8 @@ msgstr ""
 msgid "%1$s sub-trees total · the largest covers %2$s%% of all individuals"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:812
-#: src/Repository/LifeSpanRepository.php:819
+#: src/Repository/LifeSpanRepository.php:806
+#: src/Repository/LifeSpanRepository.php:813
 #: src/Repository/ParenthoodRepository.php:359
 #: src/Repository/ParenthoodRepository.php:372
 #, php-format
@@ -136,7 +136,7 @@ msgstr ""
 msgid "%1$s: %2$s deaths against an expected %3$s (Z-score %4$s)"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:1134
+#: src/Repository/LifeSpanRepository.php:1128
 #: src/Support/Locale/CenturyName.php:112
 #: src/Support/Locale/CenturyName.php:131 src/Support/Locale/DecadeName.php:53
 #: src/Support/Locale/DecadeName.php:84
@@ -858,7 +858,7 @@ msgstr "Po śmierci partnera"
 msgid "Age"
 msgstr "Wiek"
 
-#: src/Repository/LifeSpanRepository.php:919
+#: src/Repository/LifeSpanRepository.php:913
 #, php-format
 msgid "Age %s"
 msgstr "Wiek %s"
@@ -1735,7 +1735,7 @@ msgid "February"
 msgstr "Luty"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:421
-#: src/Repository/LifeSpanRepository.php:841 src/Statistic.php:228
+#: src/Repository/LifeSpanRepository.php:835 src/Statistic.php:228
 msgid "Female"
 msgstr "Kobieta"
 
@@ -2262,7 +2262,7 @@ msgid "Longevity"
 msgstr "Longevity"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:420
-#: src/Repository/LifeSpanRepository.php:834 src/Statistic.php:223
+#: src/Repository/LifeSpanRepository.php:828 src/Statistic.php:223
 msgid "Male"
 msgstr "Mężczyzna"
 
@@ -3463,8 +3463,8 @@ msgctxt "count word"
 msgid "nine"
 msgstr "nine"
 
-#: src/Repository/LifeSpanRepository.php:816
-#: src/Repository/LifeSpanRepository.php:823
+#: src/Repository/LifeSpanRepository.php:810
+#: src/Repository/LifeSpanRepository.php:817
 #: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Repository/LifeSpanRepository.php:921
+#: src/Repository/LifeSpanRepository.php:915
 #, php-format
 msgid "%1$s %% (%2$s of %3$s individuals reached this age)"
 msgstr "%1$s %% (%2$s из %3$s человек достигли этого возраста)"
@@ -96,8 +96,8 @@ msgstr ""
 msgid "%1$s sub-trees total · the largest covers %2$s%% of all individuals"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:812
-#: src/Repository/LifeSpanRepository.php:819
+#: src/Repository/LifeSpanRepository.php:806
+#: src/Repository/LifeSpanRepository.php:813
 #: src/Repository/ParenthoodRepository.php:359
 #: src/Repository/ParenthoodRepository.php:372
 #, php-format
@@ -136,7 +136,7 @@ msgstr ""
 msgid "%1$s: %2$s deaths against an expected %3$s (Z-score %4$s)"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:1134
+#: src/Repository/LifeSpanRepository.php:1128
 #: src/Support/Locale/CenturyName.php:112
 #: src/Support/Locale/CenturyName.php:131 src/Support/Locale/DecadeName.php:53
 #: src/Support/Locale/DecadeName.php:84
@@ -866,7 +866,7 @@ msgstr "После смерти партнёра"
 msgid "Age"
 msgstr "Возраст"
 
-#: src/Repository/LifeSpanRepository.php:919
+#: src/Repository/LifeSpanRepository.php:913
 #, php-format
 msgid "Age %s"
 msgstr "Возраст %s"
@@ -1745,7 +1745,7 @@ msgid "February"
 msgstr "Февраль"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:421
-#: src/Repository/LifeSpanRepository.php:841 src/Statistic.php:228
+#: src/Repository/LifeSpanRepository.php:835 src/Statistic.php:228
 msgid "Female"
 msgstr "Жен"
 
@@ -2274,7 +2274,7 @@ msgid "Longevity"
 msgstr "Longevity"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:420
-#: src/Repository/LifeSpanRepository.php:834 src/Statistic.php:223
+#: src/Repository/LifeSpanRepository.php:828 src/Statistic.php:223
 msgid "Male"
 msgstr "Муж."
 
@@ -3472,8 +3472,8 @@ msgctxt "count word"
 msgid "nine"
 msgstr "nine"
 
-#: src/Repository/LifeSpanRepository.php:816
-#: src/Repository/LifeSpanRepository.php:823
+#: src/Repository/LifeSpanRepository.php:810
+#: src/Repository/LifeSpanRepository.php:817
 #: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Repository/LifeSpanRepository.php:921
+#: src/Repository/LifeSpanRepository.php:915
 #, php-format
 msgid "%1$s %% (%2$s of %3$s individuals reached this age)"
 msgstr "%1$s %%(%3$s 人中有 %2$s 人达到此年龄)"
@@ -90,8 +90,8 @@ msgstr ""
 msgid "%1$s sub-trees total · the largest covers %2$s%% of all individuals"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:812
-#: src/Repository/LifeSpanRepository.php:819
+#: src/Repository/LifeSpanRepository.php:806
+#: src/Repository/LifeSpanRepository.php:813
 #: src/Repository/ParenthoodRepository.php:359
 #: src/Repository/ParenthoodRepository.php:372
 #, php-format
@@ -130,7 +130,7 @@ msgstr ""
 msgid "%1$s: %2$s deaths against an expected %3$s (Z-score %4$s)"
 msgstr ""
 
-#: src/Repository/LifeSpanRepository.php:1134
+#: src/Repository/LifeSpanRepository.php:1128
 #: src/Support/Locale/CenturyName.php:112
 #: src/Support/Locale/CenturyName.php:131 src/Support/Locale/DecadeName.php:53
 #: src/Support/Locale/DecadeName.php:84
@@ -820,7 +820,7 @@ msgstr "伴侣去世后"
 msgid "Age"
 msgstr "年龄"
 
-#: src/Repository/LifeSpanRepository.php:919
+#: src/Repository/LifeSpanRepository.php:913
 #, php-format
 msgid "Age %s"
 msgstr "年龄 %s"
@@ -1680,7 +1680,7 @@ msgid "February"
 msgstr "二月"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:421
-#: src/Repository/LifeSpanRepository.php:841 src/Statistic.php:228
+#: src/Repository/LifeSpanRepository.php:835 src/Statistic.php:228
 msgid "Female"
 msgstr "女性"
 
@@ -2195,7 +2195,7 @@ msgid "Longevity"
 msgstr "Longevity"
 
 #: resources/views/modules/statistics-chart/tabs/life-span.phtml:420
-#: src/Repository/LifeSpanRepository.php:834 src/Statistic.php:223
+#: src/Repository/LifeSpanRepository.php:828 src/Statistic.php:223
 msgid "Male"
 msgstr "男性"
 
@@ -3385,8 +3385,8 @@ msgctxt "count word"
 msgid "nine"
 msgstr "nine"
 
-#: src/Repository/LifeSpanRepository.php:816
-#: src/Repository/LifeSpanRepository.php:823
+#: src/Repository/LifeSpanRepository.php:810
+#: src/Repository/LifeSpanRepository.php:817
 #: src/Repository/NameRepository.php:659 src/Repository/NameRepository.php:663
 #: src/Repository/ParenthoodRepository.php:365
 #: src/Repository/ParenthoodRepository.php:378

--- a/src/Repository/LifeSpanRepository.php
+++ b/src/Repository/LifeSpanRepository.php
@@ -30,6 +30,7 @@ use MagicSunday\Webtrees\Statistic\Model\Pyramid\PopulationPyramidPayload;
 use MagicSunday\Webtrees\Statistic\Model\Ranking\RankingEntry;
 use MagicSunday\Webtrees\Statistic\Model\Record\IndividualAgeRecord;
 use MagicSunday\Webtrees\Statistic\Support\Aggregator\EventMonthTally;
+use MagicSunday\Webtrees\Statistic\Support\Calc\AgeBuckets;
 use MagicSunday\Webtrees\Statistic\Support\Calc\CalendarSpan;
 use MagicSunday\Webtrees\Statistic\Support\Calc\GregorianDate;
 use MagicSunday\Webtrees\Statistic\Support\Calc\HeatmapPeriodBinner;
@@ -51,6 +52,7 @@ use function array_fill_keys;
 use function array_key_last;
 use function array_keys;
 use function array_map;
+use function array_reverse;
 use function count;
 use function getdate;
 use function gregoriantojd;
@@ -201,13 +203,7 @@ final readonly class LifeSpanRepository
             ->groupBy('individuals.i_id')
             ->get();
 
-        $buckets = [];
-
-        for ($age = 0; $age < self::MAX_BUCKET; $age += self::BUCKET_WIDTH) {
-            $buckets[$this->bucketLabel($age)] = 0;
-        }
-
-        $buckets[$this->overflowLabel()] = 0;
+        $buckets = AgeBuckets::init(0, self::MAX_BUCKET, self::BUCKET_WIDTH);
 
         foreach ($rows as $row) {
             $cohort = $this->birthDeathCohortOrNull($row, $maxAge);
@@ -217,9 +213,7 @@ final readonly class LifeSpanRepository
             }
 
             $years = $cohort['years'];
-            $label = $years >= self::MAX_BUCKET
-                ? $this->overflowLabel()
-                : $this->bucketLabel(intdiv($years, self::BUCKET_WIDTH) * self::BUCKET_WIDTH);
+            $label = AgeBuckets::label($years, self::MAX_BUCKET, self::BUCKET_WIDTH);
 
             $buckets[$label] = ($buckets[$label] ?? 0) + 1;
         }
@@ -1434,14 +1428,6 @@ final readonly class LifeSpanRepository
     }
 
     /**
-     * "0–9", "10–19", … for a given lower-bound age.
-     */
-    private function bucketLabel(int $lowerAge): string
-    {
-        return $lowerAge . '–' . ($lowerAge + self::BUCKET_WIDTH - 1);
-    }
-
-    /**
      * The full age-at-death band axis in oldest-first order — "100+", "90–99",
      * …, "0–9" — so the population pyramid stacks the oldest cohort at the top
      * and the youngest at the base. Mirrors the bucketing of {@see
@@ -1451,13 +1437,11 @@ final readonly class LifeSpanRepository
      */
     private function ageBandLabels(): array
     {
-        $labels = [$this->overflowLabel()];
-
-        for ($age = self::MAX_BUCKET - self::BUCKET_WIDTH; $age >= 0; $age -= self::BUCKET_WIDTH) {
-            $labels[] = $this->bucketLabel($age);
-        }
-
-        return $labels;
+        return array_reverse(
+            array_keys(
+                AgeBuckets::init(0, self::MAX_BUCKET, self::BUCKET_WIDTH)
+            )
+        );
     }
 
     /**
@@ -1467,19 +1451,7 @@ final readonly class LifeSpanRepository
      */
     private function ageBandLabel(int $years): string
     {
-        if ($years >= self::MAX_BUCKET) {
-            return $this->overflowLabel();
-        }
-
-        return $this->bucketLabel(intdiv($years, self::BUCKET_WIDTH) * self::BUCKET_WIDTH);
-    }
-
-    /**
-     * Overflow bucket label for ages ≥ MAX_BUCKET.
-     */
-    private function overflowLabel(): string
-    {
-        return self::MAX_BUCKET . '+';
+        return AgeBuckets::label($years, self::MAX_BUCKET, self::BUCKET_WIDTH);
     }
 
     /**

--- a/tests/Integration/LifeSpanRepositoryIntegrationTest.php
+++ b/tests/Integration/LifeSpanRepositoryIntegrationTest.php
@@ -20,6 +20,7 @@ use MagicSunday\Webtrees\Statistic\Model\Metric\WinterPeakScore;
 use MagicSunday\Webtrees\Statistic\Model\Pyramid\PopulationPyramidPayload;
 use MagicSunday\Webtrees\Statistic\Model\Ranking\RankingEntry;
 use MagicSunday\Webtrees\Statistic\Repository\LifeSpanRepository;
+use MagicSunday\Webtrees\Statistic\Support\Calc\AgeBuckets;
 use MagicSunday\Webtrees\Statistic\Support\Calc\HistogramTrim;
 use MagicSunday\Webtrees\Statistic\Support\Database\BirthDeathPairsQuery;
 use MagicSunday\Webtrees\Statistic\Support\Database\DateAggregate;
@@ -63,6 +64,7 @@ use function sprintf;
 #[UsesClass(WinterPeakScore::class)]
 #[UsesClass(PopulationPyramidPayload::class)]
 #[UsesClass(RankingEntry::class)]
+#[UsesClass(AgeBuckets::class)]
 #[UsesClass(HistogramTrim::class)]
 #[UsesClass(BirthDeathPairsQuery::class)]
 #[UsesClass(DateAggregate::class)]


### PR DESCRIPTION
Closes #239

The age-bucket label rule was implemented three times and the copies had already drifted. The merged version keeps the union of what each one produced — not just the text of whichever was extracted first — and the result is pinned in full by a test.

## Note on CI

The `JS Typecheck` step is expected to fail on this branch until #255 lands, for a reason unrelated to this change: `typescript` is caret-ranged and no lockfile is committed, so a local install resolves an older version that still tolerates the `baseUrl` option while CI resolves one that removed it. #255 drops the option and fixes the four genuine type errors that had been masked behind the configuration failure.