### PR TITLE
Fix unlink-base deleting an unrestorable module-base

### DIFF
--- a/Make/dev.mk
+++ b/Make/dev.mk
@@ -36,14 +36,19 @@ link-base: .logo ## Symlink .build/vendor/.../webtrees-module-base to the siblin
 	@echo -e "${FGREEN} ✔${FRESET} Symlinked $(MODULE_BASE_VENDOR) → $$(cd $(MODULE_BASE_CLONE) && pwd)"
 	@echo -e "${FYELLOW}   Note:${FRESET} composer install/update will replace this symlink with a fresh checkout."
 
-unlink-base: .logo ## Restore .build/vendor/.../webtrees-module-base from composer. Runs composer on the host shell — requires composer in $PATH.
-	@if ! command -v composer >/dev/null 2>&1; then \
-		echo -e "${FRED} ✘${FRESET} composer not found on PATH. Either install composer on the host or run \`docker compose run --rm buildbox composer install\` against your webtrees buildbox manually."; \
-		exit 1; \
+unlink-base: .logo ## Remove the module-base dev symlink; print how to restore the composer checkout.
+	@if [ ! -L "$(MODULE_BASE_VENDOR)" ]; then \
+		if [ -e "$(MODULE_BASE_VENDOR)" ]; then \
+			echo -e "${FYELLOW} ⚠${FRESET} $(MODULE_BASE_VENDOR) is a real checkout, not a symlink — leaving it untouched."; \
+		else \
+			echo -e "${FYELLOW} ⚠${FRESET} $(MODULE_BASE_VENDOR) does not exist — nothing to unlink."; \
+		fi; \
+	else \
+		rm -f "$(MODULE_BASE_VENDOR)"; \
+		echo -e "${FGREEN} ✔${FRESET} Removed the dev symlink $(MODULE_BASE_VENDOR)."; \
+		echo -e "${FYELLOW}   Restore the composer checkout by running composer install for this module"; \
+		echo -e "   through the webtrees buildbox (these repos ship no PHP/composer container of their own).${FRESET}"; \
 	fi
-	@rm -rf $(MODULE_BASE_VENDOR)
-	@composer install --quiet
-	@echo -e "${FGREEN} ✔${FRESET} Restored $(MODULE_BASE_VENDOR) from composer."
 
 link-chart-lib: .logo ## Symlink node_modules/.../webtrees-chart-lib to the sibling dev clone for live editing. Uses a RELATIVE target so the symlink resolves inside the node compose container too.
 	@if [ ! -d "$(CHART_LIB_CLONE)" ]; then \

--- a/Make/dev.mk
+++ b/Make/dev.mk
@@ -31,8 +31,8 @@ link-base: .logo ## Symlink .build/vendor/.../webtrees-module-base to the siblin
 		echo -e "${FRED} ✘${FRESET} Expected sibling clone at $(MODULE_BASE_CLONE)"; \
 		exit 1; \
 	fi
-	@rm -rf $(MODULE_BASE_VENDOR)
-	@ln -s "$$(cd $(MODULE_BASE_CLONE) && pwd)" $(MODULE_BASE_VENDOR)
+	@rm -rf "$(MODULE_BASE_VENDOR)"
+	@ln -s "$$(cd $(MODULE_BASE_CLONE) && pwd)" "$(MODULE_BASE_VENDOR)"
 	@echo -e "${FGREEN} ✔${FRESET} Symlinked $(MODULE_BASE_VENDOR) → $$(cd $(MODULE_BASE_CLONE) && pwd)"
 	@echo -e "${FYELLOW}   Note:${FRESET} composer install/update will replace this symlink with a fresh checkout."
 


### PR DESCRIPTION
## The bug

`unlink-base` ran `rm -rf` on the vendored `webtrees-module-base` and then a
`composer install` that cannot run in these repos, so the restore step the target
advertises was unreliable while the delete had already happened — leaving the
module without its dependency. (The chart repos routed composer through the `node`
service, which has neither composer nor php; this one required composer on the host
PATH.)

## The fix

Guard on the symlink: only remove `MODULE_BASE_VENDOR` when it actually is a symlink
(what `link-base` creates), with `rm -f`. A real composer checkout is then left
untouched instead of deleted-and-unrestorable. The broken composer call is dropped;
the target prints how to restore through the buildbox. This unifies the four sibling
repos (`webtrees-fan-chart`, `webtrees-pedigree-chart`, `webtrees-descendants-chart`,
`webtrees-statistics`) onto one canonical, container-agnostic target — verified
byte-identical. Fixed under the `webtrees-fan-chart` tracking issue.

Verified: real checkout present → untouched; a symlink → removed, its clone target
survives; nothing present → safe no-op.

Note: this repo previously used a different, host-composer variant; it is now unified onto the canonical form above.