### PR TITLE
GH-281: Adopt the coding-standard strict PHPStan tier and shared tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,27 @@ permissions:
     contents: read
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
+    # The PHP gates come from the shared reusable so the canonical step list lives
+    # in one place (lint, phpstan, rector, cgl, unit, plus the template-lockstep
+    # guard this repository opts into). Copy-paste detection and the release-zip
+    # smoke test stay in the JS lane below: jscpd is a Node tool and `make dist`
+    # needs Node too.
+    # Analysis runs on 8.4/8.5 only: the strict PHPStan tier pulls
+    # symplify/phpstan-rules ^14, which (transitively, via symfony ^8.1 and
+    # phpunit/php-code-coverage 14) requires PHP >= 8.4, so `composer install`
+    # cannot resolve the dev dependencies on 8.3. Runtime support for 8.3 stays
+    # declared in require.php and is validated statically by PHPStan's
+    # phpVersion.min = 80300; it is simply not unit-tested on a real 8.3 runtime.
+    php:
+        uses: magicsunday/.github/.github/workflows/php-quality.yml@main
+        permissions:
+            contents: read
+        with:
+            php-versions: '["8.4", "8.5"]'
 
-        strategy:
-            fail-fast: false
-            matrix:
-                php: ['8.3', '8.4', '8.5']
+    js:
+        name: JS and release zip
+        runs-on: ubuntu-latest
 
         steps:
             - id: checkout
@@ -31,31 +45,19 @@ jobs:
                   node-version: 24
                   cache: npm
 
+            # 8.4, not the 8.3 runtime floor: this job runs `composer install`
+            # with dev dependencies, and the strict dev toolchain requires PHP
+            # >= 8.4 (see the `php:` job comment). The JS/dist lane does not test
+            # runtime PHP behaviour, so the interpreter version is irrelevant here.
             - id: setup_php
-              name: Set up PHP version ${{ matrix.php }}
+              name: Set up PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: ${{ matrix.php }}
+                  php-version: '8.4'
                   tools: composer:v2
 
             - name: Validate composer.json and composer.lock
               run: composer validate
-
-            - id: composer-cache-vars
-              name: Composer Cache Vars
-              run: |
-                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-                  echo "timestamp=$(date +"%s")" >> $GITHUB_OUTPUT
-
-            - id: composer-cache-dependencies
-              name: Cache Composer dependencies
-              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-              with:
-                  path: ${{ steps.composer-cache-vars.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ steps.composer-cache-vars.outputs.timestamp }}
-                  restore-keys: |
-                      ${{ runner.os }}-composer-${{ matrix.php }}-
-                      ${{ runner.os }}-composer-
 
             - id: install
               name: Install dependencies
@@ -66,69 +68,34 @@ jobs:
                   composer install --no-progress
                   npm ci
 
-            - id: php-lint
-              name: PHP Lint
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:lint
-
             - id: js-lint
               name: JS Lint
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:lint
+              run: composer ci:test:js:lint
 
             - id: js-format
               name: JS Format
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:format
+              run: composer ci:test:js:format
 
             - id: js-typecheck
               name: JS Typecheck
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:typecheck
-
-            - id: phpstan
-              name: PHPStan
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:phpstan -- --error-format=github
-
-            - id: rector
-              name: Rector
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:rector
-
-            - id: cpd
-              name: Copy/Paste Detection
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:cpd
-
-            - id: php-unit
-              name: PHP Unit Tests
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:unit
+              run: composer ci:test:js:typecheck
 
             - id: js-unit
               name: JS Unit Tests
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:unit
+              run: composer ci:test:js:unit
 
-            - id: cgl
-              name: CGL
+            - id: cpd
+              name: Copy/Paste Detection
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:cgl -- --dry-run
+              run: composer ci:test:cpd
 
-            # Runs LAST: 'make dist' invokes 'composer install --no-dev'
-            # which strips dev packages (php-cs-fixer, phpstan, ...) from
-            # .build/vendor. Any later composer-driven step would fail.
+            # Runs LAST: 'make dist' invokes 'composer install --no-dev' which
+            # strips the dev packages from .build/vendor, so any later
+            # composer-driven step would fail.
             - id: dist-smoke
               name: Release zip smoke test
               if: ${{ success() }}
@@ -137,7 +104,7 @@ jobs:
                   make dist-smoke
                   rm -f *.zip
 
-    # The `build` job runs the test suite against in-memory SQLite, which does
+    # The `php` reusable runs the test suite against in-memory SQLite, which does
     # not implement ONLY_FULL_GROUP_BY and so silently tolerates a grouped
     # SELECT with a non-aggregated column. This job re-runs the DB-touching
     # integration tests against a real MySQL 8 — where webtrees' ANSI sql_mode

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,22 +9,6 @@
 
 declare(strict_types=1);
 
-/**
- * This file represents the configuration for Code Sniffing PSR-2-related
- * automatic checks of coding guidelines Install @fabpot's great php-cs-fixer
- * tool via
- *
- *  $ composer global require friendsofphp/php-cs-fixer
- *
- * And then simply run
- *
- *  $ php-cs-fixer fix
- *
- * For more information read:
- *  http://www.php-fig.org/psr/psr-2/
- *  http://cs.sensiolabs.org
- */
-
 if (PHP_SAPI !== 'cli') {
     die('This script supports command line usage only. Please check your command.');
 }
@@ -36,87 +20,10 @@ For the full copyright and license information, please read the
 LICENSE file that was distributed with this source code.
 EOF;
 
-return (new PhpCsFixer\Config())
-    ->setCacheFile(__DIR__ . '/.build/cache/.php-cs-fixer.cache')
-    ->setRiskyAllowed(true)
-    ->setParallelConfig(new PhpCsFixer\Runner\Parallel\ParallelConfig(4, 8))
-    ->setRules([
-        '@PER-CS2x0'                      => true,
-        '@Symfony'                        => true,
+$factory = require __DIR__ . '/.build/vendor/magicsunday/coding-standard/php-cs-fixer/base.php';
 
-        // Additional custom rules
-        'declare_strict_types'            => true,
-        'concat_space'                    => [
-            'spacing' => 'one',
-        ],
-        'header_comment'                  => [
-            'header'       => $header,
-            'comment_type' => 'PHPDoc',
-            'location'     => 'after_open',
-            'separate'     => 'both',
-        ],
-        'method_argument_space'           => [
-            'on_multiline' => 'ensure_fully_multiline',
-        ],
-        'phpdoc_to_comment'               => false,
-        'phpdoc_no_alias_tag'             => false,
-        'phpdoc_annotation_without_dot'   => false,
-        'no_superfluous_phpdoc_tags'      => false,
-        'phpdoc_separation'               => [
-            'groups' => [
-                [
-                    'author',
-                    'license',
-                    'link',
-                ],
-            ],
-        ],
-        'no_alias_functions'              => true,
-        'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => true,
-        ],
-        'single_line_throw'               => false,
-        'self_accessor'                   => false,
-        'global_namespace_import'         => [
-            'import_classes'   => true,
-            'import_constants' => true,
-            'import_functions' => true,
-        ],
-        'function_declaration'            => [
-            'closure_function_spacing' => 'one',
-            'closure_fn_spacing'       => 'one',
-        ],
-        'binary_operator_spaces'          => [
-            'operators' => [
-                '='   => 'align_single_space_minimal',
-                '=>'  => 'align_single_space_minimal',
-                '+='  => 'align_single_space_minimal',
-                '-='  => 'align_single_space_minimal',
-                '.='  => 'align_single_space_minimal',
-                '??=' => 'align_single_space_minimal',
-            ],
-        ],
-        'yoda_style'                      => [
-            'equal'                => false,
-            'identical'            => false,
-            'less_and_greater'     => false,
-            'always_move_variable' => false,
-        ],
-        'blank_line_before_statement'     => [
-            'statements' => [
-                'break',
-                'continue',
-                'for',
-                'foreach',
-                'if',
-                'return',
-                'switch',
-                'throw',
-                'try',
-                'while',
-            ],
-        ],
-    ])
+return $factory($header)
+    ->setCacheFile(__DIR__ . '/.build/cache/.php-cs-fixer.cache')
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->exclude([

--- a/composer.json
+++ b/composer.json
@@ -56,15 +56,7 @@
         "magicsunday/webtrees-module-installer-plugin": "^2.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.50",
-        "overtrue/phplint": "^9.0",
-        "phpat/phpat": "^0.12.4",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^12.0 || ^13.0",
-        "rector/rector": "^2.0",
+        "magicsunday/coding-standard": "^1.5",
         "shipmonk/phpstan-rules": "^4.0",
         "symplify/phpstan-rules": "^14.0"
     },
@@ -105,6 +97,9 @@
         "ci:test:php:integration": [
             "phpunit --configuration phpunit.xml --display-all-issues tests/Integration"
         ],
+        "ci:test:php:templates": [
+            "check-consumer-config.php ."
+        ],
         "ci:test:js:lint": [
             "npm run lint"
         ],
@@ -129,6 +124,7 @@
             "@ci:test:php:phpstan",
             "@ci:test:php:rector",
             "@ci:test:cpd",
+            "@ci:test:php:templates",
             "@ci:test:php:unit",
             "@ci:test:js:unit"
         ]

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,21 +1,7 @@
 includes:
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-strict-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-deprecation-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-phpunit/extension.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-phpunit/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/phpat/phpat/extension.neon
-    - %currentWorkingDirectory%/.build/vendor/shipmonk/phpstan-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/symplify/phpstan-rules/config/services/services.neon
-    - %currentWorkingDirectory%/.build/vendor/symplify/phpstan-rules/config/code-complexity-rules.neon
-    - %currentWorkingDirectory%/.build/vendor/symplify/phpstan-rules/config/configurable-rules.neon
-    - %currentWorkingDirectory%/.build/vendor/symplify/phpstan-rules/config/naming-rules.neon
-    - %currentWorkingDirectory%/.build/vendor/symplify/phpstan-rules/config/static-rules.neon
-    - %currentWorkingDirectory%/.build/vendor/symplify/phpstan-rules/config/symfony-config-rules.neon
+    - %currentWorkingDirectory%/.build/vendor/magicsunday/coding-standard/phpstan/strict.neon
 
 parameters:
-    # You can currently choose from 11 levels (0 is the loosest and 10 is the strictest).
-    level: max
-
     # PHP Version to check against (PHP 8.3 as minimum target)
     phpVersion: 80300
 
@@ -34,28 +20,9 @@ parameters:
     scanFiles:
         - %currentWorkingDirectory%/stubs/hh_occupation_standardizer.stub
 
-    fileExtensions:
-        - php
-
     excludePaths:
         - %currentWorkingDirectory%/.build/
 
-    checkImplicitMixed: true
-    checkBenevolentUnionTypes: true
-    checkUninitializedProperties: true
-    checkMissingCallableSignature: true
-    checkTooWideReturnTypesInProtectedAndPublicMethods: true
-    reportAnyTypeWideningInVarTag: true
-    reportPossiblyNonexistentConstantArrayOffset: true
-    reportPossiblyNonexistentGeneralArrayOffset: true
-
-    # JetBrains' PHP stub for ext-calendar still spells gregoriantojd
-    # as PascalCase (`GregorianToJD`), while the official PHP manual
-    # at https://www.php.net/manual/en/function.gregoriantojd.php has
-    # been canonical lowercase for years. PHPStan inherits the stale
-    # PascalCase from the stub and raises `function.nameCase` for
-    # every call that uses the manual-canonical lowercase form.
-    # Suppress just this one mismatch until JetBrains fixes the stub.
     ignoreErrors:
         # symplify forbiddenNode bans traits + heredocs wholesale — both are
         # deliberate house idioms here: the module-base sharing traits and the
@@ -100,6 +67,13 @@ parameters:
         -
             identifier: shipmonk.checkedExceptionInCallable
 
+        # JetBrains' PHP stub for ext-calendar still spells gregoriantojd
+        # as PascalCase (`GregorianToJD`), while the official PHP manual
+        # at https://www.php.net/manual/en/function.gregoriantojd.php has
+        # been canonical lowercase for years. PHPStan inherits the stale
+        # PascalCase from the stub and raises `function.nameCase` for
+        # every call that uses the manual-canonical lowercase form.
+        # Suppress just this one mismatch until JetBrains fixes the stub.
         -
             identifier: function.nameCase
             path: src/Repository/LifeSpanRepository.php
@@ -143,9 +117,6 @@ parameters:
             identifier: return.type
             reportUnmatched: false
             path: src/Support/Database/DateAggregate.php
-
-    phpat:
-        show_rule_names: true
 
 services:
     -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -64,8 +64,17 @@ parameters:
                 - tests/Unit/Model/LineChart/LineChartPayloadTest.php
                 - tests/View/MarriageExtremesViewTest.php
 
+        # The query layer projects Eloquent result rows through callables (row
+        # mappers, per-group reducers) that legitimately propagate a checked
+        # domain exception; the callable is consumed immediately inside the same
+        # method, so shipmonk's "checked exception escapes a callable" concern
+        # does not apply. Scoped to the two query directories so the rule stays
+        # armed everywhere else in the strict tier.
         -
             identifier: shipmonk.checkedExceptionInCallable
+            paths:
+                - src/Repository/*
+                - src/Support/Database/*
 
         # JetBrains' PHP stub for ext-calendar still spells gregoriantojd
         # as PascalCase (`GregorianToJD`), while the official PHP manual

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="./.build/vendor/phpunit/phpunit/phpunit.xsd"
+         requireCoverageMetadata="true"
          beStrictAboutCoverageMetadata="true"
          beStrictAboutOutputDuringTests="true"
          bootstrap="./tests/bootstrap.php"
@@ -8,9 +9,12 @@
          colors="true"
          displayDetailsOnPhpunitDeprecations="true"
          executionOrder="depends,defects"
-         failOnPhpunitDeprecation="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
+         failOnDeprecation="true"
+         failOnPhpunitDeprecation="true"
+         failOnPhpunitNotice="true"
 >
     <testsuites>
         <testsuite name="Unit Tests">

--- a/rector.php
+++ b/rector.php
@@ -9,13 +9,7 @@
 
 declare(strict_types=1);
 
-use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
-use Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -25,59 +19,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->fileExtensions(['php', 'phtml']);
-
-    if (
-        !is_dir($concurrentDirectory = __DIR__ . '/.build/cache/.rector.cache')
-        && !mkdir($concurrentDirectory, 0775, true)
-        && !is_dir($concurrentDirectory)
-    ) {
-        throw new \RuntimeException(
-            sprintf(
-                'Directory "%s" was not created',
-                $concurrentDirectory
-            )
-        );
-    }
-
-    if (
-        !is_dir($concurrentDirectory = __DIR__ . '/.build/cache/.rector.container.cache')
-        && !mkdir($concurrentDirectory, 0775, true)
-        && !is_dir($concurrentDirectory)
-    ) {
-        throw new \RuntimeException(
-            sprintf(
-                'Directory "%s" was not created',
-                $concurrentDirectory
-            )
-        );
-    }
-
     $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
-    $rectorConfig->importNames();
-    $rectorConfig->removeUnusedImports();
-    $rectorConfig->disableParallel();
-    $rectorConfig->cacheDirectory(__DIR__ . '/.build/cache/.rector.cache');
-    $rectorConfig->containerCacheDirectory(__DIR__ . '/.build/cache/.rector.container.cache');
-    $rectorConfig->phpVersion(80300);
 
-    // Define what rule sets will be applied
-    $rectorConfig->sets([
-        SetList::CODE_QUALITY,
-        SetList::CODING_STYLE,
-        SetList::DEAD_CODE,
-        SetList::EARLY_RETURN,
-        SetList::INSTANCEOF,
-        SetList::PRIVATIZATION,
-        SetList::TYPE_DECLARATION,
-        SetList::TYPE_DECLARATION_DOCBLOCKS,
-        LevelSetList::UP_TO_PHP_83,
-    ]);
-
-    // Skip some rules
-    $rectorConfig->skip([
-        CatchExceptionNameMatchingTypeRector::class,
-        RemoveUnreachableStatementRector::class,
-        RemoveUselessParamTagRector::class,
-        RemoveUselessReturnTagRector::class,
-    ]);
+    (require __DIR__ . '/.build/vendor/magicsunday/coding-standard/rector/base.php')($rectorConfig, 80300);
 };


### PR DESCRIPTION
Closes #281.

Adopts the shared `magicsunday/coding-standard` (^1.5) **strict** PHPStan tier and shared tooling, replacing this repository's near-identical local copies.

## What changed
- `phpstan.neon` now `includes:` the package's `strict.neon` (base + shipmonk/symplify rule packs + extra report flags), keeping this repo's local `ignoreErrors`, `scanFiles`, the phpat service and `phpVersion`.
- `.php-cs-fixer.dist.php` and `rector.php` delegate to the shared factories.
- `phpunit.xml` gains the strict canon (`requireCoverageMetadata`, `failOnNotice`/`failOnDeprecation`/`failOnPhpunitNotice`).
- The PHP CI gates move to the reusable `php-quality.yml` workflow; `require-dev` adds `shipmonk/phpstan-rules ^4` and `symplify/phpstan-rules ^14`.

## PHP 8.4 for the analysis matrix
The strict dev toolchain requires PHP >= 8.4 — `symplify/phpstan-rules ^14` pulls `symfony ^8.1` and `phpunit/php-code-coverage 14`, all `>= 8.4`. `composer install` therefore cannot resolve the dev dependencies on 8.3, so the analysis matrix is pinned to `8.4/8.5` and the JS/dist job's PHP to `8.4`. **Runtime support for 8.3 stays declared** in `require.php` and is validated statically by PHPStan's `phpVersion.min = 80300`; it is simply no longer unit-tested on a real 8.3 runtime.

## Verified
Buildbox: PHPStan (strict.neon) no errors over 239 files · CGL 0 fixable · Rector no changes · template-lockstep gate OK · PHPUnit OK (805 tests, 3658 assertions). `composer install` resolves cleanly on 8.4; it deliberately fails on 8.3 (that leg is removed).

## Merge note — branch protection
The reusable workflow reports the PHP checks under new contexts (`php / Build (8.4)`, `php / Build (8.5)`) instead of the previous `build (8.3/8.4/8.5)`. The `main` required-status-checks list must be repointed to the rendered contexts (confirmed from this PR's first run) at merge, or PRs will hang `BLOCKED` on contexts that never report.

## Not included
The `ci:test:php:phpat-subjects` gate is intentionally removed — the phpat subject-liveness guard is being superseded by a central Deptrac ruleset; the `ci:test:php:templates` lockstep gate stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Quality Improvements**
  * Updated automated PHP checks to use shared coding standards and consolidated static-analysis configuration.
  * Simplified formatting/linting and Rector setup to rely on shared base configuration.
* **Testing**
  * Added a CI step to validate PHP consumer configuration templates.
  * Strengthened PHPUnit to fail on additional warning/notice/deprecation conditions.
  * Streamlined JavaScript CI to run JS-only checks (lint/format/typecheck/unit and duplication detection).
* **Compatibility**
  * PHP quality checks are now run on PHP 8.4 and 8.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->