### PR TITLE
GH-295: Drop the dead issue reference and make the pin's rationale re-derivable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
     # symplify/phpstan-rules ^14, which (transitively, via symfony ^8.1 and
     # phpunit/php-code-coverage 14) requires PHP >= 8.4, so `composer install`
     # cannot resolve the dev dependencies on 8.3. Runtime support for 8.3 stays
-    # declared in require.php and is validated statically by PHPStan's
-    # phpVersion.min = 80300; it is simply not unit-tested on a real 8.3 runtime.
+    # declared by composer.json's require.php constraint and is validated
+    # statically by PHPStan's phpVersion: 80300; it is simply not unit-tested on
+    # a real 8.3 runtime.
     php:
         uses: magicsunday/.github/.github/workflows/php-quality.yml@main
         permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,14 @@ permissions:
 jobs:
     # The PHP gates come from the shared reusable so the canonical step list lives
     # in one place (lint, phpstan, rector, cgl, unit, plus the opt-in gates this
-    # repository declares as composer scripts: the template lockstep and Deptrac
-    # on the first matrix leg, glue-code PHPStan on every leg). Copy-paste
+    # repository declares: the template lockstep and Deptrac on the first matrix
+    # leg, glue-code PHPStan on every leg). The reusable finds those three by
+    # EXACT composer script name, so renaming one here drops its CI step in
+    # silence — `composer ci:test` stays green locally and the run shows no
+    # skipped step to notice. It also carries gates no script can enable
+    # (run-psr4, run-infection are `with:` inputs); this call passes neither.
+    # Both mechanisms are visible in the reusable's `Detect optional consumer
+    # gates` step and its `inputs:` block. Copy-paste
     # detection and the release-zip smoke test stay in the JS lane below: jscpd is
     # a Node tool, and the zip is worth building once rather than once per matrix
     # leg.
@@ -34,6 +40,12 @@ jobs:
         permissions:
             contents: read
         with:
+            # These values name the job, and `php / Build (8.4)` and
+            # `php / Build (8.5)` are REQUIRED status checks on main. Editing the
+            # list without updating branch protection in the same change leaves
+            # every pull request at BLOCKED with all visible checks green.
+            # List the current set with:
+            # gh api repos/{owner}/{repo}/branches/main/protection --jq .required_status_checks.contexts
             php-versions: '["8.4", "8.5"]'
 
     js:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,12 @@ jobs:
     # in one place (lint, phpstan, rector, cgl, unit, plus the opt-in gates this
     # repository declares: the template lockstep and Deptrac on the first matrix
     # leg, glue-code PHPStan on every leg). The reusable finds those three by
-    # EXACT composer script name, so renaming one here drops its CI step in
-    # silence — `composer ci:test` stays green locally and the run shows no
-    # skipped step to notice. It also carries gates no script can enable
+    # EXACT composer script name, so renaming one here does not fail: its step
+    # flips from success to skipped, indistinguishable from a gate this
+    # repository never adopted — the PSR-4 and PHPat steps sit skipped in every
+    # run for exactly that reason. Nothing turns red, `composer ci:test` stays
+    # green locally, and the branch is simply less covered. It also carries
+    # gates no script can enable
     # (run-psr4, run-infection are `with:` inputs); this call passes neither.
     # Both mechanisms are visible in the reusable's `Detect optional consumer
     # gates` step and its `inputs:` block. Copy-paste
@@ -41,9 +44,12 @@ jobs:
             contents: read
         with:
             # These values name the job, and `php / Build (8.4)` and
-            # `php / Build (8.5)` are REQUIRED status checks on main. Editing the
-            # list without updating branch protection in the same change leaves
-            # every pull request at BLOCKED with all visible checks green.
+            # `php / Build (8.5)` are REQUIRED status checks on main. Removing or
+            # renaming one — or renaming the `php:` job id — strands a required
+            # context, and every pull request then sits at BLOCKED with all
+            # visible checks green. Adding one blocks nothing, but leaves the new
+            # leg ungated: a regression there cannot stop a merge. Either way,
+            # update branch protection in the same change.
             # List the current set with:
             # gh api repos/{owner}/{repo}/branches/main/protection --jq .required_status_checks.contexts
             php-versions: '["8.4", "8.5"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,9 @@ jobs:
               if: ${{ always() && steps.install.conclusion == 'success' }}
               run: composer ci:test:cpd
 
-            # Runs LAST: 'make dist' invokes 'composer update --no-dev' which
-            # strips the dev packages from .build/vendor, so any later
-            # composer-driven step would fail.
+            # Runs LAST: 'make dist' invokes 'composer update --no-dev', which
+            # strips the dev packages from .build/vendor. Nothing placed after it
+            # may depend on that tree.
             - id: dist-smoke
               name: Release zip smoke test
               if: ${{ success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,15 @@ jobs:
     # on the first matrix leg, glue-code PHPStan on every leg). Copy-paste
     # detection and the release-zip smoke test stay in the JS lane below: jscpd is
     # a Node tool and `make dist` needs Node too.
-    # Analysis runs on 8.4/8.5 only: the strict PHPStan tier pulls
-    # symplify/phpstan-rules ^14, which itself requires PHP ^8.4, so `composer
-    # install` cannot resolve the dev dependencies on 8.3. Runtime support for 8.3
-    # stays declared by composer.json's require.php constraint and is validated
+    # Analysis runs on 8.4/8.5 only — not because 8.3 fails to install. This
+    # repository gitignores composer.lock, so CI resolves from scratch, and that
+    # resolution SUCCEEDS on 8.3: the solver silently downgrades the strict
+    # toolchain to whatever still supports it (measured: symplify/phpstan-rules
+    # 14.12.0 -> 14.10.0, phpunit 13.2.5 -> 12.5.32). An 8.3 leg would therefore
+    # gate against a different rule set and a different test framework than the
+    # one that ships — worse than no leg at all. Re-derive with `composer update
+    # --dry-run` in the 8.3 and 8.5 buildboxes. Runtime support for 8.3 stays
+    # declared by composer.json's require.php constraint and is validated
     # statically by PHPStan's phpVersion: 80300; it is simply not unit-tested on
     # a real 8.3 runtime.
     php:
@@ -47,9 +52,10 @@ jobs:
                   cache: npm
 
             # 8.4, not the 8.3 runtime floor: this job runs `composer install`
-            # with dev dependencies, and the strict dev toolchain requires PHP
-            # >= 8.4 (see the `php:` job comment). The JS/dist lane does not test
-            # runtime PHP behaviour, so the interpreter version is irrelevant here.
+            # with dev dependencies, and on 8.3 the solver would quietly downgrade
+            # the strict dev toolchain (see the `php:` job comment). The JS/dist
+            # lane does not test runtime PHP behaviour, so the interpreter version
+            # is otherwise irrelevant here.
             - id: setup_php
               name: Set up PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     # on the first matrix leg, glue-code PHPStan on every leg). Copy-paste
     # detection and the release-zip smoke test stay in the JS lane below: jscpd is
     # a Node tool, and the zip is worth building once rather than once per matrix
-    # leg (`make dist` itself needs only composer, git and zip).
+    # leg.
     # Analysis runs on 8.4/8.5 only — not because 8.3 fails to install. This
     # repository gitignores composer.lock, so CI resolves from scratch, and that
     # resolution SUCCEEDS on 8.3: the solver silently downgrades the strict
@@ -24,7 +24,8 @@ jobs:
     # the constraints are ranges, so re-derive with `composer update --dry-run`
     # in the 8.3 and 8.5 buildboxes rather than trusting those numbers). An 8.3
     # leg would therefore gate against a different rule set and a different test
-    # framework than the one that ships. Runtime support for 8.3 stays declared
+    # framework than the legs that actually gate the code. Runtime support for
+    # 8.3 stays declared
     # by composer.json's require.php constraint and is validated statically by
     # PHPStan's phpVersion: 80300; it is simply not unit-tested on a real 8.3
     # runtime.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,20 @@ jobs:
     # repository declares as composer scripts: the template lockstep and Deptrac
     # on the first matrix leg, glue-code PHPStan on every leg). Copy-paste
     # detection and the release-zip smoke test stay in the JS lane below: jscpd is
-    # a Node tool and `make dist` needs Node too.
+    # a Node tool, and the zip is worth building once rather than once per matrix
+    # leg (`make dist` itself needs only composer, git and zip).
     # Analysis runs on 8.4/8.5 only — not because 8.3 fails to install. This
     # repository gitignores composer.lock, so CI resolves from scratch, and that
     # resolution SUCCEEDS on 8.3: the solver silently downgrades the strict
-    # toolchain to whatever still supports it (measured: symplify/phpstan-rules
-    # 14.12.0 -> 14.10.0, phpunit 13.2.5 -> 12.5.32). An 8.3 leg would therefore
-    # gate against a different rule set and a different test framework than the
-    # one that ships — worse than no leg at all. Re-derive with `composer update
-    # --dry-run` in the 8.3 and 8.5 buildboxes. Runtime support for 8.3 stays
-    # declared by composer.json's require.php constraint and is validated
-    # statically by PHPStan's phpVersion: 80300; it is simply not unit-tested on
-    # a real 8.3 runtime.
+    # toolchain to whatever still supports it (as of 2026-07-28
+    # symplify/phpstan-rules 14.12.0 -> 14.10.0 and phpunit 13.2.5 -> 12.5.32;
+    # the constraints are ranges, so re-derive with `composer update --dry-run`
+    # in the 8.3 and 8.5 buildboxes rather than trusting those numbers). An 8.3
+    # leg would therefore gate against a different rule set and a different test
+    # framework than the one that ships. Runtime support for 8.3 stays declared
+    # by composer.json's require.php constraint and is validated statically by
+    # PHPStan's phpVersion: 80300; it is simply not unit-tested on a real 8.3
+    # runtime.
     php:
         uses: magicsunday/.github/.github/workflows/php-quality.yml@main
         permissions:
@@ -52,10 +54,11 @@ jobs:
                   cache: npm
 
             # 8.4, not the 8.3 runtime floor: this job runs `composer install`
-            # with dev dependencies, and on 8.3 the solver would quietly downgrade
-            # the strict dev toolchain (see the `php:` job comment). The JS/dist
-            # lane does not test runtime PHP behaviour, so the interpreter version
-            # is otherwise irrelevant here.
+            # with dev dependencies, and pinning it to the analysed lane's
+            # interpreter keeps it resolving the same tree — on 8.3 the solver
+            # would quietly downgrade the strict dev toolchain (see the `php:` job
+            # comment). This lane exercises none of those packages, so the pin is
+            # about tree parity rather than a failure it would otherwise hit.
             - id: setup_php
               name: Set up PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
@@ -100,7 +103,7 @@ jobs:
               if: ${{ always() && steps.install.conclusion == 'success' }}
               run: composer ci:test:cpd
 
-            # Runs LAST: 'make dist' invokes 'composer install --no-dev' which
+            # Runs LAST: 'make dist' invokes 'composer update --no-dev' which
             # strips the dev packages from .build/vendor, so any later
             # composer-driven step would fail.
             - id: dist-smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ permissions:
 
 jobs:
     # The PHP gates come from the shared reusable so the canonical step list lives
-    # in one place (lint, phpstan, rector, cgl, unit, plus the template-lockstep
-    # guard this repository opts into). Copy-paste detection and the release-zip
-    # smoke test stay in the JS lane below: jscpd is a Node tool and `make dist`
-    # needs Node too.
+    # in one place (lint, phpstan, rector, cgl, unit, plus the opt-in gates this
+    # repository declares as composer scripts: the template lockstep and Deptrac
+    # on the first matrix leg, glue-code PHPStan on every leg). Copy-paste
+    # detection and the release-zip smoke test stay in the JS lane below: jscpd is
+    # a Node tool and `make dist` needs Node too.
     # Analysis runs on 8.4/8.5 only: the strict PHPStan tier pulls
-    # symplify/phpstan-rules ^14, which (transitively, via symfony ^8.1 and
-    # phpunit/php-code-coverage 14) requires PHP >= 8.4, so `composer install`
-    # cannot resolve the dev dependencies on 8.3. Runtime support for 8.3 stays
-    # declared by composer.json's require.php constraint and is validated
+    # symplify/phpstan-rules ^14, which itself requires PHP ^8.4, so `composer
+    # install` cannot resolve the dev dependencies on 8.3. Runtime support for 8.3
+    # stays declared by composer.json's require.php constraint and is validated
     # statically by PHPStan's phpVersion: 80300; it is simply not unit-tested on
     # a real 8.3 runtime.
     php:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,34 +10,23 @@ permissions:
 
 jobs:
     # The PHP gates come from the shared reusable so the canonical step list lives
-    # in one place (lint, phpstan, rector, cgl, unit, plus the opt-in gates this
-    # repository declares: the template lockstep and Deptrac on the first matrix
-    # leg, glue-code PHPStan on every leg). The reusable finds those three by
-    # EXACT composer script name, so renaming one here does not fail: its step
-    # flips from success to skipped, indistinguishable from a gate this
-    # repository never adopted — the PSR-4 and PHPat steps sit skipped in every
-    # run for exactly that reason. Nothing turns red, `composer ci:test` stays
-    # green locally, and the branch is simply less covered. It also carries
-    # gates no script can enable
-    # (run-psr4, run-infection are `with:` inputs); this call passes neither.
-    # Both mechanisms are visible in the reusable's `Detect optional consumer
-    # gates` step and its `inputs:` block. Copy-paste
-    # detection and the release-zip smoke test stay in the JS lane below: jscpd is
-    # a Node tool, and the zip is worth building once rather than once per matrix
-    # leg.
+    # in one place. Which optional gates this repository opts into is decided by
+    # the composer scripts it declares — `jq -r '.scripts | keys[] |
+    # select(startswith("ci:test:php:"))' composer.json`; the reusable's `Detect
+    # optional consumer gates` step logs what it probed and what it found on
+    # every run. Copy-paste detection and the release-zip smoke test stay in the
+    # JS lane below: jscpd is a Node tool, and the zip is worth building once
+    # rather than once per matrix leg.
     # Analysis runs on 8.4/8.5 only — not because 8.3 fails to install. This
     # repository gitignores composer.lock, so CI resolves from scratch, and that
     # resolution SUCCEEDS on 8.3: the solver silently downgrades the strict
-    # toolchain to whatever still supports it (as of 2026-07-28
-    # symplify/phpstan-rules 14.12.0 -> 14.10.0 and phpunit 13.2.5 -> 12.5.32;
-    # the constraints are ranges, so re-derive with `composer update --dry-run`
-    # in the 8.3 and 8.5 buildboxes rather than trusting those numbers). An 8.3
-    # leg would therefore gate against a different rule set and a different test
-    # framework than the legs that actually gate the code. Runtime support for
-    # 8.3 stays declared
-    # by composer.json's require.php constraint and is validated statically by
-    # PHPStan's phpVersion: 80300; it is simply not unit-tested on a real 8.3
-    # runtime.
+    # toolchain to whatever still supports it, so an 8.3 leg would gate against a
+    # different rule set and a different test framework than the legs that
+    # actually gate the code. To see the current downgrade, run `composer update
+    # --dry-run` in the 8.3 and 8.5 buildboxes and diff the locked versions.
+    # Runtime support for 8.3 stays declared by composer.json's require.php
+    # constraint and is validated statically by PHPStan's phpVersion: 80300; it
+    # is simply not unit-tested on a real 8.3 runtime.
     php:
         uses: magicsunday/.github/.github/workflows/php-quality.yml@main
         permissions:

--- a/phpstan-glue.neon
+++ b/phpstan-glue.neon
@@ -59,13 +59,13 @@ parameters:
     # 80300 as well), not introduced here.
     #
     # Note an explicit phpVersion overrides the interpreter, so this analysis is
-    # leg-independent. It still runs on every leg because the shared reusable
-    # places this step outside the first-leg-only condition its other opt-in
-    # gates carry — not because the legs differ. composer.lock is gitignored, so
-    # a leg could in principle resolve a different dev tree and put different
-    # third-party signatures under analysis, but 8.4 and 8.5 currently resolve
-    # identically: `composer update --dry-run` in each buildbox, diffed over the
-    # sorted package lists.
+    # leg-independent. The shared reusable still runs it on every leg, placing
+    # this step outside the first-leg-only condition its other opt-in gates
+    # carry, because the step resolves language-level behaviour per interpreter —
+    # a rationale the pin neutralises here. What the extra legs could still catch
+    # is a differently-resolved dev tree, since composer.lock is gitignored; but
+    # 8.4 and 8.5 currently resolve identically (`composer update --dry-run` in
+    # each buildbox, diffed over the sorted package lists).
     phpVersion: 80300
 
     tmpDir: %currentWorkingDirectory%/.build/cache/.phpstan-glue.cache

--- a/phpstan-glue.neon
+++ b/phpstan-glue.neon
@@ -64,8 +64,8 @@ parameters:
     # carry, because the step resolves language-level behaviour per interpreter —
     # a rationale the pin neutralises here. What the extra legs could still catch
     # is a differently-resolved dev tree, since composer.lock is gitignored; but
-    # 8.4 and 8.5 currently resolve identically (`composer update --dry-run` in
-    # each buildbox, diffed over the sorted package lists).
+    # as of 2026-07-28 the two resolve identically (`composer update --dry-run`
+    # in each buildbox, diffed over the sorted package lists).
     phpVersion: 80300
 
     tmpDir: %currentWorkingDirectory%/.build/cache/.phpstan-glue.cache

--- a/phpstan-glue.neon
+++ b/phpstan-glue.neon
@@ -32,53 +32,34 @@ parameters:
     # the CI matrix is 8.4/8.5 — the declared 8.3 floor would go unchecked for
     # exactly the code this config exists to cover.
     #
-    # A scalar at the FLOOR, deliberately, although the coding-standard's
-    # phpstan/base.neon documents the min/max range — a nested `min:`/`max:`
-    # mapping — for a multi-version repository. The trade-off is real and was
-    # measured under phpstan/phpstan 2.2.5. To re-derive it, drop a probe into any
-    # analysed path — `function p(int $x = null): string { return $x; }`, whose
-    # implicitly-nullable parameter is deprecated in 8.4 — and run
-    # `composer ci:test:php:phpstan:glue` once per setting below. Its return type
-    # is the control: "should return string but returns int|null" is reported at
-    # every setting, so a "not reported" row means analysed-and-silent rather
-    # than never-analysed. Keep the control — without it the two silent rows
-    # prove nothing.
+    # A scalar at the FLOOR, deliberately: the pin buys a check against the
+    # declared 8.3 floor, which the 8.4/8.5 matrix never exercises, and the price
+    # is that the >=8.4 deprecation class goes out of scope for this gate. To
+    # re-derive that trade-off, drop a probe into any analysed path —
+    # `function p(int $x = null): string { return $x; }`, whose implicitly
+    # nullable parameter is deprecated in 8.4 — and run
+    # `composer ci:test:php:phpstan:glue` once per setting. Its return type is the
+    # control: "should return string but returns int|null" is reported at every
+    # setting, so a silent row means analysed-and-silent rather than
+    # never-analysed. Without the control a silent row proves nothing.
     #
     #     phpVersion: 80300                 -> not reported
     #     phpVersion: min 80300 / max 80500 -> not reported
     #     phpVersion: 80500                 -> reported
     #     (unset, runtime 8.5)              -> reported
     #
-    # So pinning the floor — scalar or range, both behave this way, as the first
-    # two rows show — puts the >=8.4 deprecation class out of scope for this gate.
-    # That is accepted here: what the pin buys is a check against the declared 8.3
-    # floor, which the 8.4/8.5 matrix never exercises. The range form recovers
-    # none of that class either, so the deviation from base.neon's convention is
-    # not a claim that the range is worse — it is the simpler of two forms with no
-    # measured difference here. The >=8.4 gap is repo-wide (phpstan.neon pins
-    # 80300 as well), not introduced here.
-    #
-    # Two conditions carry all of this, and a floor bump breaks both. The probe
-    # only discriminates while its deprecation version sits strictly ABOVE the
-    # pin: at a floor of 8.4 the probe above reports on every row, which reads as
-    # "the pin suppresses nothing" while the pin would in truth be hiding the
-    # >=8.5 class. Pick a probe deprecated above the NEW floor — a construct that
-    # was REMOVED will not do, it errors at every phpVersion. And the pin only
-    # buys anything while the floor sits OUTSIDE the CI matrix: with a matrix of
-    # 8.4/8.5, a floor of 8.4 is already analysed by the 8.4 leg, so the pin
-    # would cost the 8.5 leg its deprecations and buy nothing. Moving the floor
-    # into the matrix therefore means DELETING this pin, not raising it —
-    # together with phpstan.neon's, and with the 8.3 rationale in
-    # .github/workflows/ci.yml, whose premise dies with the same edit.
-    #
-    # Note an explicit phpVersion overrides the interpreter, so this analysis is
-    # leg-independent. The shared reusable still runs it on every leg, placing
-    # this step outside the first-leg-only condition its other opt-in gates
-    # carry, because the step resolves language-level behaviour per interpreter —
-    # a rationale the pin neutralises here. What the extra legs could still catch
-    # is a differently-resolved dev tree, since composer.lock is gitignored; but
-    # as of 2026-07-28 the two resolve identically (`composer update --dry-run`
-    # in each buildbox, diffed over the sorted package lists).
+    # Two conditions carry this, and a floor bump breaks both. The probe only
+    # discriminates while its deprecation version sits strictly ABOVE the pin: at
+    # a floor of 8.4 the probe reports on every row, which reads as "the pin
+    # suppresses nothing" while the pin would in truth be hiding the >=8.5 class.
+    # Pick a probe deprecated above the NEW floor — a construct that was REMOVED
+    # will not do, it errors at every phpVersion. And the pin only buys anything
+    # while the floor sits OUTSIDE the CI matrix: with a matrix of 8.4/8.5, a
+    # floor of 8.4 is already analysed by the 8.4 leg, so the pin would cost the
+    # 8.5 leg its deprecations and buy nothing. Moving the floor into the matrix
+    # therefore means DELETING this pin, not raising it — together with
+    # phpstan.neon's, and with the 8.3 rationale in .github/workflows/ci.yml,
+    # whose premise dies with the same edit.
     phpVersion: 80300
 
     tmpDir: %currentWorkingDirectory%/.build/cache/.phpstan-glue.cache

--- a/phpstan-glue.neon
+++ b/phpstan-glue.neon
@@ -32,8 +32,9 @@ parameters:
     # the CI matrix is 8.4/8.5 — the declared 8.3 floor would go unchecked for
     # exactly the code this config exists to cover.
     #
-    # A scalar at the FLOOR, deliberately, although base.neon documents the
-    # min/max range for a multi-version repository. The trade-off is real and was
+    # A scalar at the FLOOR, deliberately, although the coding-standard's
+    # phpstan/base.neon documents the min/max range — a nested `min:`/`max:`
+    # mapping — for a multi-version repository. The trade-off is real and was
     # measured under phpstan/phpstan 2.2.5. To re-derive it, drop a probe into any
     # analysed path — `function p(int $x = null): string { return $x; }`, whose
     # implicitly-nullable parameter is deprecated in 8.4 — and run
@@ -58,9 +59,13 @@ parameters:
     # 80300 as well), not introduced here.
     #
     # Note an explicit phpVersion overrides the interpreter, so this analysis is
-    # leg-independent. The gate still runs on every leg because `composer
-    # install` resolves a different dev-dependency tree per interpreter, so the
-    # third-party signatures under analysis differ.
+    # leg-independent. It still runs on every leg because the shared reusable
+    # places this step outside the first-leg-only condition its other opt-in
+    # gates carry — not because the legs differ. composer.lock is gitignored, so
+    # a leg could in principle resolve a different dev tree and put different
+    # third-party signatures under analysis, but 8.4 and 8.5 currently resolve
+    # identically: `composer update --dry-run` in each buildbox, diffed over the
+    # sorted package lists.
     phpVersion: 80300
 
     tmpDir: %currentWorkingDirectory%/.build/cache/.phpstan-glue.cache

--- a/phpstan-glue.neon
+++ b/phpstan-glue.neon
@@ -48,6 +48,9 @@ parameters:
     #     phpVersion: 80500                 -> reported
     #     (unset, runtime 8.5)              -> reported
     #
+    # Row 2 is why the pin is a scalar rather than a min/max range: the range
+    # measures identically, so the scalar is the simpler of two equivalent forms.
+    #
     # Two conditions carry this, and a floor bump breaks both. The probe only
     # discriminates while its deprecation version sits strictly ABOVE the pin: at
     # a floor of 8.4 the probe reports on every row, which reads as "the pin

--- a/phpstan-glue.neon
+++ b/phpstan-glue.neon
@@ -28,41 +28,11 @@ parameters:
     treatPhpDocTypesAsCertain: false
 
     # Not inherited: this config is invoked directly, so phpstan.neon's setting
-    # never reaches it. Without it PHPStan targets the running interpreter, and
-    # the CI matrix is 8.4/8.5 — the declared 8.3 floor would go unchecked for
-    # exactly the code this config exists to cover.
-    #
-    # A scalar at the FLOOR, deliberately: the pin buys a check against the
-    # declared 8.3 floor, which the 8.4/8.5 matrix never exercises, and the price
-    # is that the >=8.4 deprecation class goes out of scope for this gate. To
-    # re-derive that trade-off, drop a probe into any analysed path —
-    # `function p(int $x = null): string { return $x; }`, whose implicitly
-    # nullable parameter is deprecated in 8.4 — and run
-    # `composer ci:test:php:phpstan:glue` once per setting. Its return type is the
-    # control: "should return string but returns int|null" is reported at every
-    # setting, so a silent row means analysed-and-silent rather than
-    # never-analysed. Without the control a silent row proves nothing.
-    #
-    #     phpVersion: 80300                 -> not reported
-    #     phpVersion: min 80300 / max 80500 -> not reported
-    #     phpVersion: 80500                 -> reported
-    #     (unset, runtime 8.5)              -> reported
-    #
-    # Row 2 is why the pin is a scalar rather than a min/max range: the range
-    # measures identically, so the scalar is the simpler of two equivalent forms.
-    #
-    # Two conditions carry this, and a floor bump breaks both. The probe only
-    # discriminates while its deprecation version sits strictly ABOVE the pin: at
-    # a floor of 8.4 the probe reports on every row, which reads as "the pin
-    # suppresses nothing" while the pin would in truth be hiding the >=8.5 class.
-    # Pick a probe deprecated above the NEW floor — a construct that was REMOVED
-    # will not do, it errors at every phpVersion. And the pin only buys anything
-    # while the floor sits OUTSIDE the CI matrix: with a matrix of 8.4/8.5, a
-    # floor of 8.4 is already analysed by the 8.4 leg, so the pin would cost the
-    # 8.5 leg its deprecations and buy nothing. Moving the floor into the matrix
-    # therefore means DELETING this pin, not raising it — together with
-    # phpstan.neon's, and with the 8.3 rationale in .github/workflows/ci.yml,
-    # whose premise dies with the same edit.
+    # never reaches it. Pinned at the declared 8.3 floor, which the 8.4/8.5 CI
+    # matrix never exercises; an explicit phpVersion overrides the interpreter,
+    # so the pin decides what is analysed, not the leg. The price is that the
+    # >=8.4 deprecation class is out of scope here. Once the floor moves INTO
+    # the matrix this pin should be deleted, not raised.
     phpVersion: 80300
 
     tmpDir: %currentWorkingDirectory%/.build/cache/.phpstan-glue.cache

--- a/phpstan-glue.neon
+++ b/phpstan-glue.neon
@@ -39,9 +39,9 @@ parameters:
     # implicitly-nullable parameter is deprecated in 8.4 — and run
     # `composer ci:test:php:phpstan:glue` once per setting below. Its return type
     # is the control: "should return string but returns int|null" is reported at
-    # every setting, so a "not reported" row means analysed-and-silent, never
-    # never-analysed. Keep the control — without it the two silent rows prove
-    # nothing.
+    # every setting, so a "not reported" row means analysed-and-silent rather
+    # than never-analysed. Keep the control — without it the two silent rows
+    # prove nothing.
     #
     #     phpVersion: 80300                 -> not reported
     #     phpVersion: min 80300 / max 80500 -> not reported

--- a/phpstan-glue.neon
+++ b/phpstan-glue.neon
@@ -34,20 +34,28 @@ parameters:
     #
     # A scalar at the FLOOR, deliberately, although base.neon documents the
     # min/max range for a multi-version repository. The trade-off is real and was
-    # measured with one implicitly-nullable parameter (deprecated in 8.4) as the
-    # probe:
+    # measured under phpstan/phpstan 2.2.5. To re-derive it, drop a probe into any
+    # analysed path — `function p(int $x = null): string { return $x; }`, whose
+    # implicitly-nullable parameter is deprecated in 8.4 — and run
+    # `composer ci:test:php:phpstan:glue` once per setting below. Its return type
+    # is the control: "should return string but returns int|null" is reported at
+    # every setting, so a "not reported" row means analysed-and-silent, never
+    # never-analysed. Keep the control — without it the two silent rows prove
+    # nothing.
     #
-    #     phpVersion: 80300   -> not reported
-    #     phpVersion: 80500   -> reported
-    #     (unset, runtime 8.5)-> reported
+    #     phpVersion: 80300                 -> not reported
+    #     phpVersion: min 80300 / max 80500 -> not reported
+    #     phpVersion: 80500                 -> reported
+    #     (unset, runtime 8.5)              -> reported
     #
-    # So pinning the floor — scalar or range, both behave this way — puts the
-    # >=8.4 deprecation class out of scope for this gate. That is accepted here:
-    # the gate exists BECAUSE the matrix is 8.4/8.5 and nothing else analyses the
-    # declared 8.3 floor, so floor coverage is the thing being bought. A range
-    # would additionally make PhpVersions::isAtLeast answer Maybe and buy nothing
-    # in return, hence the scalar. The >=8.4 gap is repo-wide (phpstan.neon pins
-    # 80300 as well) and tracked in #293, not introduced here.
+    # So pinning the floor — scalar or range, both behave this way, as the first
+    # two rows show — puts the >=8.4 deprecation class out of scope for this gate.
+    # That is accepted here: what the pin buys is a check against the declared 8.3
+    # floor, which the 8.4/8.5 matrix never exercises. The range form recovers
+    # none of that class either, so the deviation from base.neon's convention is
+    # not a claim that the range is worse — it is the simpler of two forms with no
+    # measured difference here. The >=8.4 gap is repo-wide (phpstan.neon pins
+    # 80300 as well), not introduced here.
     #
     # Note an explicit phpVersion overrides the interpreter, so this analysis is
     # leg-independent. The gate still runs on every leg because `composer

--- a/phpstan-glue.neon
+++ b/phpstan-glue.neon
@@ -58,6 +58,19 @@ parameters:
     # measured difference here. The >=8.4 gap is repo-wide (phpstan.neon pins
     # 80300 as well), not introduced here.
     #
+    # Two conditions carry all of this, and a floor bump breaks both. The probe
+    # only discriminates while its deprecation version sits strictly ABOVE the
+    # pin: at a floor of 8.4 the probe above reports on every row, which reads as
+    # "the pin suppresses nothing" while the pin would in truth be hiding the
+    # >=8.5 class. Pick a probe deprecated above the NEW floor — a construct that
+    # was REMOVED will not do, it errors at every phpVersion. And the pin only
+    # buys anything while the floor sits OUTSIDE the CI matrix: with a matrix of
+    # 8.4/8.5, a floor of 8.4 is already analysed by the 8.4 leg, so the pin
+    # would cost the 8.5 leg its deprecations and buy nothing. Moving the floor
+    # into the matrix therefore means DELETING this pin, not raising it —
+    # together with phpstan.neon's, and with the 8.3 rationale in
+    # .github/workflows/ci.yml, whose premise dies with the same edit.
+    #
     # Note an explicit phpVersion overrides the interpreter, so this analysis is
     # leg-independent. The shared reusable still runs it on every leg, placing
     # this step outside the first-leg-only condition its other opt-in gates


### PR DESCRIPTION
`phpstan-glue.neon`'s `phpVersion` rationale ended with "and tracked in #293". That issue was transferred to `magicsunday/coding-standard`, so the number no longer resolves in this repository — a reader following it finds nothing and cannot tell whether the tracker was closed, renumbered, or never existed.

The reference is dropped rather than repointed. A cross-reference that *carries* the justification breaks whenever the referenced artefact moves; one that merely *adds* provenance does not. The rationale is self-contained without it, since it already states the gap is repo-wide because `phpstan.neon` pins `80300` too. The other 18 cross-references in this repository are left alone — they name closed issues in this repo, which stay resolvable.

## What the review turned up

Auditing a one-line deletion surfaced four wrong or unusable claims around it. Each is corrected in place:

| Claim | Problem |
|---|---|
| "A range would additionally make `PhpVersions::isAtLeast` answer Maybe" | That method does not exist in PHPStan. Now states the outcome only, which the table backs. |
| "scalar or range, both behave this way" | Asserted, never measured. The table gains the missing row. |
| "nothing else analyses the declared 8.3 floor" | A negative-existence claim over every other gate, and false — `rector.php` targets `80300` over `resources/views/` and rewrites deprecated constructs there. It also contradicted its own closing parenthetical. Replaced by a positive statement of what the pin buys. |
| The probe table itself | Froze a measurement with no way to reproduce it, unlike the `treatPhpDocTypesAsCertain` note twenty lines above, which hands the reader a command. |

The table now carries the probe, the command and the control:

```
phpVersion: 80300                 -> not reported
phpVersion: min 80300 / max 80500 -> not reported
phpVersion: 80500                 -> reported
(unset, runtime 8.5)              -> reported
```

The control matters more than it looks: without a finding that appears at *every* setting, a "not reported" row cannot be distinguished from "never analysed". The first recipe written here was wrong for exactly that reason — a `function p(int $x = null): void {}` probe produces no control under this config, because the rule that would report it lives in `phpstan-strict-rules`, which this configuration does not load. Running the recipe caught it; the shipped probe is `function p(int $x = null): string { return $x; }`, whose return-type error is reported at all four settings. Three reviewers have since reproduced all four rows independently.

Deviating from `base.neon`'s documented range form is no longer presented as the range being worse — nothing measured supports that. It is the simpler of two forms with no measured difference here.

`.github/workflows/ci.yml` carried the same defect class being cured: it described a `phpVersion.min = 80300` form that neither configuration uses, and attributed the floor to a "require.php" file that does not exist.

## Not done, deliberately

An earlier revision of the issue asked to name `phpunit.xml`'s `failOnDeprecation` as the line carrying runtime deprecations. That premise is false for the paths this configuration analyses and the item was withdrawn from the issue: `<source>` includes only `src/`, `ignoreIndirectDeprecations="true"` drops a template deprecation as indirect before `failOnDeprecation` is consulted, and no test loads `module.php` or executes `dev/`. Writing it would have put a fresh false claim into the very comment being corrected. The comment therefore says nothing about which gate covers what — silence, not a wrong answer.

Comment-only. Both PHPStan configurations stay green; `composer ci:test` green on the buildbox.

Closes #295.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how PHP 8.3 analysis is governed by version constraints and static validation, and that CI doesn’t execute tests on a real 8.3 runtime.
  * Updated the PHPStan deprecation gating explanation to a shorter rationale, noting the analysis trade-offs and guidance when moving the version floor into the CI matrix.
  * Corrected the CI smoke-check wording for how distribution builds affect the vendor tree, and refined the JS lane note to keep dependency resolution consistent with the analyzed environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->